### PR TITLE
Enable `bucket_policy_only` by default, allowing overrides on a per-bucket level

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Functional examples are included in the
 | admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list | `<list>` | no |
 | bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
+| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list | `<list>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -8,6 +8,7 @@ This example illustrates how to use the `cloud-storage` module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | n/a | yes |
 | names | Names of the buckets to create. | list | n/a | yes |
 | prefix | Prefix used to generate bueckt names. | string | n/a | yes |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -21,7 +21,8 @@ provider "google" {
 module "cloud_storage" {
   source = "../.."
 
-  project_id = "${var.project_id}"
-  prefix     = "${var.prefix}"
-  names      = "${var.names}"
+  project_id         = "${var.project_id}"
+  prefix             = "${var.prefix}"
+  names              = "${var.names}"
+  bucket_policy_only = "${var.bucket_policy_only}"
 }

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -28,3 +28,8 @@ variable "prefix" {
   description = "Prefix used to generate bueckt names."
   type        = "string"
 }
+
+variable "bucket_policy_only" {
+  description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
+  type        = "map"
+}

--- a/main.tf
+++ b/main.tf
@@ -23,12 +23,13 @@ locals {
 }
 
 resource "google_storage_bucket" "buckets" {
-  count         = "${length(var.names)}"
-  name          = "${var.prefix}-${lower(element(var.names, count.index))}"
-  project       = "${var.project_id}"
-  location      = "${var.location}"
-  storage_class = "${var.storage_class}"
-  labels        = "${var.labels}"
+  count              = "${length(var.names)}"
+  name               = "${var.prefix}-${lower(element(var.names, count.index))}"
+  project            = "${var.project_id}"
+  bucket_policy_only = "${lookup(var.bucket_policy_only, lower(element(var.names, count.index)), true)}"
+  location           = "${var.location}"
+  storage_class      = "${var.storage_class}"
+  labels             = "${var.labels}"
 
   versioning {
     enabled = "${

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -29,4 +29,9 @@ module "example" {
   project_id = "${var.project_id}"
   prefix     = "${random_pet.main.id}"
   names      = ["one", "two"]
+
+  bucket_policy_only = {
+    "one" = true
+    "two" = false
+  }
 }

--- a/test/integration/simple_example/controls/gsutil.rb
+++ b/test/integration/simple_example/controls/gsutil.rb
@@ -21,4 +21,16 @@ control "gsutil" do
     its(:stdout) { should include "#{attribute("names")[0]}" }
     its(:stdout) { should include "#{attribute("names")[1]}" }
   end
+
+  describe command("gsutil bucketpolicyonly get gs://#{attribute("names")[0]}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    its(:stdout) { should include "Enabled: True" }
+  end
+
+  describe command("gsutil bucketpolicyonly get gs://#{attribute("names")[1]}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    its(:stdout) { should include "Enabled: False" }
+  end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,11 @@ variable "versioning" {
   default     = {}
 }
 
+variable "bucket_policy_only" {
+  description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
+  default     = {}
+}
+
 variable "admins" {
   description = "IAM-style members who will be granted roles/storage.objectAdmin on all buckets."
   default     = []


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/4