### PR TITLE
Update Makefile & test setup for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ crash.log
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
+test/source.sh
 **/*.tfvars
 
 credentials.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,20 @@
 
 This document provides guidelines for contributing to the module.
 
+## Dependencies
+
+The following dependencies must be installed on the development system:
+
+- [Docker Engine][docker-engine]
+- [Google Cloud SDK][google-cloud-sdk]
+- [make]
+
 ## Generating Documentation for Inputs and Outputs
 
 The Inputs and Outputs tables in the READMEs of the root module,
 submodules, and example modules are automatically generated based on
 the `variables` and `outputs` of the respective modules. These tables
 must be refreshed if the module interfaces are changed.
-
-### Dependencies
-
-The following dependencies must be installed on the development system:
-
-- [make]
-- [terraform-docs] v0.6.0
 
 ### Execution
 
@@ -31,70 +32,58 @@ The integration tests are run using [Kitchen][kitchen],
 tools are packaged within a Docker image for convenience.
 
 The general strategy for these tests is to verify the behaviour of the
-[example modules](./examples), thus ensuring that the root module,
+[example modules](./examples/), thus ensuring that the root module,
 submodules, and example modules are all functionally correct.
 
-### Dependencies
+### Test Environment
+The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
 
-The following dependencies must be installed on the development system:
+To use this setup, you need a service account with Project Creator access on a folder. Export the Service Account credentials to your environment like so:
 
-- [Docker Engine][docker-engine]
-- [Google Cloud SDK][google-cloud-sdk]
-- [make]
+```
+export SERVICE_ACCOUNT_JSON=$(< credentials.json)
+```
 
-### Inputs
+You will also need to set a few environment variables:
+```
+export TF_VAR_org_id="your_org_id"
+export TF_VAR_folder_id="your_folder_id"
+export TF_VAR_billing_account="your_billing_account_id"
+```
 
-Test instances are defined in the
-[Kitchen configuration file](./kitchen.yml). The inputs of each Kitchen
-instance may be configured with the `driver.variables` key in a
-local Kitchen configuration file located at `./kitchen.local.yml` or in
-a Terraform variables file located at
-`./test/fixtures/<instance>/variables.tfvars`.
+With these settings in place, you can prepare a test project using Docker:
+```
+make docker_test_prepare
+```
 
-### Credentials
+### Noninteractive Execution
 
-Download the key of a Service Account with the
-[required roles][required-roles] to `./credentials.json`.
+Run `make docker_test_integration` to test all of the example modules
+noninteractively, using the prepared test project.
 
 ### Interactive Execution
 
 1. Run `make docker_run` to start the testing Docker container in
    interactive mode.
 
-1. Run `kitchen create <EXAMPLE_NAME>` to initialize the working
+1. Run `kitchen_do create <EXAMPLE_NAME>` to initialize the working
    directory for an example module.
 
-1. Run `kitchen converge <EXAMPLE_NAME>` to apply the example module.
+1. Run `kitchen_do converge <EXAMPLE_NAME>` to apply the example module.
 
-1. Run `kitchen verify <EXAMPLE_NAME>` to test the example module.
+1. Run `kitchen_do verify <EXAMPLE_NAME>` to test the example module.
 
-1. Run `kitchen destroy <EXAMPLE_NAME>` to destroy the example module
+1. Run `kitchen_do destroy <EXAMPLE_NAME>` to destroy the example module
    state.
-
-### Noninteractive Execution
-
-Run `make test_integration_docker` to test all of the example modules
-noninteractively.
 
 ## Linting and Formatting
 
 Many of the files in the repository can be linted or formatted to
 maintain a standard of quality.
 
-### Dependencies
-
-The following dependencies must be installed on the development system:
-
-- [flake8]
-- [gofmt]
-- [hadolint]
-- [make]
-- [shellcheck]
-- [Terraform][terraform] v0.11
-
 ### Execution
 
-Run `make check`.
+Run `make docker_test_lint`.
 
 [docker-engine]: https://www.docker.com/products/docker-engine
 [flake8]: http://flake8.pycqa.org/en/latest/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,137 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
-# Please make sure to contribute relevant changes upstream!
-
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-# Docker build config variables
-CREDENTIALS_PATH 			?= /cft/workdir/credentials.json
-DOCKER_ORG 				:= gcr.io/cloud-foundation-cicd
-DOCKER_TAG_BASE_KITCHEN_TERRAFORM 	?= 2.3.0
-DOCKER_REPO_BASE_KITCHEN_TERRAFORM 	:= ${DOCKER_ORG}/cft/kitchen-terraform:${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.1.0
+DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
+REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
-# All is the first target in the file so it will get picked up when you just run 'make' on its own
-.PHONY: all
-all: check generate_docs
-
-# Run all available linters
-.PHONY: check
-check: check_python check_golang check_terraform check_base_files test_check_headers check_headers check_trailing_whitespace
-
-# The .PHONY directive tells make that this isn't a real target and so
-# the presence of a file named 'check_shell' won't cause this target to stop
-# working
-.PHONY: check_shell
-check_shell:
-	@source test/make.sh && check_shell
-
-.PHONY: check_python
-check_python:
-	@source test/make.sh && check_python
-
-.PHONY: check_golang
-check_golang:
-	@source test/make.sh && golang
-
-.PHONY: check_terraform
-check_terraform:
-	@source test/make.sh && check_terraform
-
-.PHONY: check_docker
-check_docker:
-	@source test/make.sh && docker
-
-.PHONY: check_base_files
-check_base_files:
-	@source test/make.sh && basefiles
-
-.PHONY: check_trailing_whitespace
-check_trailing_whitespace:
-	@source test/make.sh && check_trailing_whitespace
-
-.PHONY: test_check_headers
-test_check_headers:
-	@echo "Testing the validity of the header check"
-	@python test/test_verify_boilerplate.py
-
-.PHONY: check_headers
-check_headers:
-	@source test/make.sh && check_headers
-
-# Integration tests
-.PHONY: test_integration
-test_integration:
-	test/ci_integration.sh
-
-.PHONY: generate_docs
-generate_docs:
-	@source test/make.sh && generate_docs
-
-# Versioning
-.PHONY: version
-version:
-	@source helpers/version-repo.sh
-
-# Run docker
+# Enter docker container for local development
 .PHONY: docker_run
 docker_run:
 	docker run --rm -it \
-		-e PROJECT_ID \
 		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && exec /bin/bash"
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/bin/bash
 
-.PHONY: docker_create
-docker_create:
+# Execute prepare tests within the docker container
+.PHONY: docker_test_prepare
+docker_test_prepare:
 	docker run --rm -it \
-		-e PROJECT_ID \
 		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && kitchen create"
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_billing_account \
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/execute_with_credentials.sh prepare_environment
 
-.PHONY: docker_converge
-docker_converge:
+# Clean up test environment within the docker container
+.PHONY: docker_test_cleanup
+docker_test_prepare:
 	docker run --rm -it \
-		-e PROJECT_ID \
 		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && kitchen converge"
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_billing_account \
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/execute_with_credentials.sh cleanup_environment
 
-.PHONY: docker_verify
-docker_verify:
+# Execute integration tests within the docker container
+.PHONY: docker_test_integration
+docker_test_integration:
 	docker run --rm -it \
-		-e PROJECT_ID \
 		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && kitchen verify"
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/test_integration.sh
 
-.PHONY: docker_destroy
-docker_destroy:
+# Execute lint tests within the docker container
+.PHONY: docker_test_lint
+docker_test_lint:
 	docker run --rm -it \
-		-e PROJECT_ID \
-		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && kitchen destroy"
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/test_lint.sh
 
-.PHONY: test_integration_docker
-test_integration_docker:
+# Generate documentation
+.PHONY: docker_generate_docs
+docker_generate_docs:
 	docker run --rm -it \
-		-e PROJECT_ID \
-		-e SERVICE_ACCOUNT_JSON \
-		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
-		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "cd /cft/workdir && source test/ci_integration.sh && setup_environment && make test_integration"
+		-v $(CURDIR):/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+
+# Alias for backwards compatibility
+.PHONY: generate_docs
+generate_docs: docker_generate_docs

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: create
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create']
+- id: converge
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge']
+- id: verify
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify']
+- id: destroy
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.1.0'

--- a/test/setup/.gitignore
+++ b/test/setup/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+source.sh

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -1,0 +1,35 @@
+# Integration Testing
+
+Use this directory to create resources reflecting the same resource fixtures
+created for use by the CI environment CI integration test pipelines.  The intent
+of these resources is to run the integration tests locally as closely as
+possible to how they will run in the CI system.
+
+Once created, store the service account key content into the
+`SERVICE_ACCOUNT_JSON` environment variable. This reflects the same behavior
+as used in CI.
+
+For example:
+
+```bash
+terraform init
+terraform apply
+mkdir -p ~/.credentials
+terraform output sa_key | base64 --decode > ~/.credentials/network-sa.json
+```
+
+Then, configure the environment (suggest using direnv) like so:
+
+```bash
+export SERVICE_ACCOUNT_JSON=$(cat ${HOME}/.credentials/network-sa.json)
+export PROJECT_ID="network-module"
+```
+
+With these variables set, change to the root of the module and execute the
+`make test_integration` task. This make target is the same that is executed
+by this module's CI pipeline during integration testing, and will run the
+integration tests from your machine.
+
+Alternatively, to run the integration tests directly from the Docker
+container used by the module's CI pipeline, perform the above steps and then
+run the `make test_integration_docker` target

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -15,14 +15,14 @@ For example:
 terraform init
 terraform apply
 mkdir -p ~/.credentials
-terraform output sa_key | base64 --decode > ~/.credentials/network-sa.json
+terraform output sa_key | base64 --decode > ~/.credentials/cloud-storage-sa.json
 ```
 
 Then, configure the environment (suggest using direnv) like so:
 
 ```bash
-export SERVICE_ACCOUNT_JSON=$(cat ${HOME}/.credentials/network-sa.json)
-export PROJECT_ID="network-module"
+export SERVICE_ACCOUNT_JSON=$(cat ${HOME}/.credentials/cloud-storage-sa.json)
+export PROJECT_ID="cloud-storage-module"
 ```
 
 With these variables set, change to the root of the module and execute the

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  int_required_roles = [
+    "roles/compute.networkAdmin",
+    "roles/compute.securityAdmin",
+    "roles/iam.serviceAccountUser",
+  ]
+}
+
+resource "google_service_account" "int_test" {
+  project      = module.project.project_id
+  account_id   = "ci-network"
+  display_name = "ci-network"
+}
+
+resource "google_project_iam_member" "int_test" {
+  count = length(local.int_required_roles)
+
+  project = module.project.project_id
+  role    = local.int_required_roles[count.index]
+  member  = "serviceAccount:${google_service_account.int_test.email}"
+}
+
+resource "google_service_account_key" "int_test" {
+  service_account_id = google_service_account.int_test.id
+}

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -16,16 +16,15 @@
 
 locals {
   int_required_roles = [
-    "roles/compute.networkAdmin",
-    "roles/compute.securityAdmin",
+    "roles/storage.admin",
     "roles/iam.serviceAccountUser",
   ]
 }
 
 resource "google_service_account" "int_test" {
   project      = module.project.project_id
-  account_id   = "ci-network"
-  display_name = "ci-network"
+  account_id   = "ci-cloud-storage"
+  display_name = "ci-cloud-storage"
 }
 
 resource "google_project_iam_member" "int_test" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 3.0"
+
+  name              = "ci-network"
+  random_project_id = "true"
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
+
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "serviceusage.googleapis.com"
+  ]
+}

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -18,7 +18,7 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 3.0"
 
-  name              = "ci-network"
+  name              = "ci-cloud-storage"
   random_project_id = "true"
   org_id            = var.org_id
   folder_id         = var.folder_id

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -25,6 +25,7 @@ module "project" {
   billing_account   = var.billing_account
 
   activate_apis = [
+    "storage-api.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "serviceusage.googleapis.com"

--- a/test/setup/make_source.sh
+++ b/test/setup/make_source.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "#!/usr/bin/env bash" > ../source.sh
+
+project_id=$(terraform output project_id)
+echo "export TF_VAR_project_id='$project_id'" >> ../source.sh
+
+sa_json=$(terraform output sa_key)
+# shellcheck disable=SC2086
+echo "export SERVICE_ACCOUNT_JSON='$(echo $sa_json | base64 --decode)'" >> ../source.sh

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value = module.project.project_id
+}
+
+output "sa_key" {
+  value     = google_service_account_key.int_test.private_key
+  sensitive = true
+}

--- a/test/setup/variables.tf
+++ b/test/setup/variables.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+variable "org_id" {
+  description = "The numeric organization id"
+}
+
+variable "folder_id" {
+  description = "The folder to deploy in"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+}

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
It seems like this module is using outdated testing container & Makefile for CI, so here's an update.

Was able to successfully run tests locally. Took these from the terraform-google-network module.