### PR TITLE
Include name of bucket as label for cost analysis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "google_storage_bucket" "buckets" {
   project       = var.project_id
   location      = var.location
   storage_class = var.storage_class
-  labels        = var.labels
+  labels        = merge(var.labels, { name = "${local.prefix}${lower(element(var.names, count.index))}" })
   force_destroy = lookup(
     var.force_destroy,
     lower(element(var.names, count.index)),


### PR DESCRIPTION
If we create numerous buckets with a single instance of this module they will all have the same labels as it stands today.

When exporting cost metrics to bigquery we may want to distinguish the cost per bucket.

When performing cost queries, labels are the way to group resources today (unfortunately we cannot query on bucket name), adding the unique name as a label is a good way to perform a query on a single bucket with regards to its' cost. Until Big Query cost analysis let's us query on the bucket name, this is a workaround.

Thoughts?