### PR TITLE
Replace dot on a dash in label value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "google_storage_bucket" "buckets" {
   project       = var.project_id
   location      = var.location
   storage_class = var.storage_class
-  labels        = merge(var.labels, { name = "${local.prefix}${lower(element(var.names, count.index))}" })
+  labels        = merge(var.labels, { name = replace("${local.prefix}${lower(element(var.names, count.index))}", ".", "-") })
   force_destroy = lookup(
     var.force_destroy,
     lower(element(var.names, count.index)),


### PR DESCRIPTION
I want to create a bucket by verified domain name.
![image](https://user-images.githubusercontent.com/9011975/72988296-0b127280-3dfd-11ea-89ac-83b38bf566c6.png)

I do it through terraform:
```
Error: googleapi: Error 400: Invalid argument, invalid

  on .terraform/modules/cloud_storage/terraform-google-modules-terraform-google-cloud-storage-c011106/main.tf line 21, in resource "google_storage_bucket" "buckets":
  21: resource "google_storage_bucket" "buckets" {


```

I do it through web UI:
![image](https://user-images.githubusercontent.com/9011975/72988434-4ca31d80-3dfd-11ea-8a0a-c747ce5dae1a.png)

All because of the line, it forbids me to create baskets with domain names through terraforms.
https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/master/main.tf#L27

Because label value have only hyphens (-), underscores (_), lowercase characters, and numbers are allowed. International characters are allowed.