### PR TITLE
Be able to use a custom IAM role to grant to viewers/creators/admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,28 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list | `<list>` | no |
+| admins | IAM-style members who will be granted roles/storage.objectAdmin (or our custom_role defined on admins_custom_role) on all buckets. | list(string) | `<list>` | no |
+| admins\_custom\_role | The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name} | string | `""` | no |
 | bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
-| creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list | `<list>` | no |
+| creators | IAM-style members who will be granted roles/storage.objectCreators (or our custom_role defined on creators_custom_role) on all buckets. | list(string) | `<list>` | no |
+| creators\_custom\_role | The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name} | string | `""` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
-| prefix | Prefix used to generate the bucket name. | string | n/a | yes |
+| prefix | Prefix used to generate the bucket name. | string | `""` | no |
 | project\_id | Bucket project id. | string | n/a | yes |
-| set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | string | `"false"` | no |
-| set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | string | `"false"` | no |
-| set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | string | `"false"` | no |
+| set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
+| set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |
+| set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | bool | `"false"` | no |
 | storage\_class | Bucket storage class. | string | `"MULTI_REGIONAL"` | no |
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
-| viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | list | `<list>` | no |
+| viewers | IAM-style members who will be granted roles/storage.objectViewer (or our custom_role defined on viewers_custom_role) on all buckets. | list(string) | `<list>` | no |
+| viewers\_custom\_role | The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name} | string | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "google_storage_bucket" "buckets" {
 resource "google_storage_bucket_iam_binding" "admins" {
   count  = var.set_admin_roles ? length(var.names) : 0
   bucket = element(google_storage_bucket.buckets.*.name, count.index)
-  role   = "roles/storage.objectAdmin"
+  role   = var.admins_custom_role == "" ? "roles/storage.objectAdmin" : var.admins_custom_role
   members = compact(
     concat(
       var.admins,
@@ -80,7 +80,7 @@ resource "google_storage_bucket_iam_binding" "admins" {
 resource "google_storage_bucket_iam_binding" "creators" {
   count  = var.set_creator_roles ? length(var.names) : 0
   bucket = element(google_storage_bucket.buckets.*.name, count.index)
-  role   = "roles/storage.objectCreator"
+  role   = var.creators_custom_role == "" ? "roles/storage.objectCreator" : var.creators_custom_role
   members = compact(
     concat(
       var.creators,
@@ -95,7 +95,7 @@ resource "google_storage_bucket_iam_binding" "creators" {
 resource "google_storage_bucket_iam_binding" "viewers" {
   count  = var.set_viewer_roles ? length(var.names) : 0
   bucket = element(google_storage_bucket.buckets.*.name, count.index)
-  role   = "roles/storage.objectViewer"
+  role   = var.viewers_custom_role == "" ? "roles/storage.objectViewer" : var.viewers_custom_role
   members = compact(
     concat(
       var.viewers,

--- a/variables.tf
+++ b/variables.tf
@@ -16,10 +16,13 @@
 
 variable "project_id" {
   description = "Bucket project id."
+  type        = string
 }
 
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
+  default     = ""
+  type        = string
 }
 
 variable "names" {
@@ -30,11 +33,13 @@ variable "names" {
 variable "location" {
   description = "Bucket location."
   default     = "EU"
+  type        = string
 }
 
 variable "storage_class" {
   description = "Bucket storage class."
   default     = "MULTI_REGIONAL"
+  type        = string
 }
 
 variable "force_destroy" {
@@ -53,18 +58,39 @@ variable "bucket_policy_only" {
 }
 
 variable "admins" {
-  description = "IAM-style members who will be granted roles/storage.objectAdmin on all buckets."
+  description = "IAM-style members who will be granted roles/storage.objectAdmin (or our custom_role defined on admins_custom_role) on all buckets."
   default     = []
+  type        = list(string)
+}
+
+variable "admins_custom_role" {
+  description = "The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name}"
+  default     = ""
+  type        = string
 }
 
 variable "creators" {
-  description = "IAM-style members who will be granted roles/storage.objectCreators on all buckets."
+  description = "IAM-style members who will be granted roles/storage.objectCreators (or our custom_role defined on creators_custom_role) on all buckets."
   default     = []
+  type        = list(string)
+}
+
+variable "creators_custom_role" {
+  description = "The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name}"
+  default     = ""
+  type        = string
 }
 
 variable "viewers" {
-  description = "IAM-style members who will be granted roles/storage.objectViewer on all buckets."
+  description = "IAM-style members who will be granted roles/storage.objectViewer (or our custom_role defined on viewers_custom_role) on all buckets."
   default     = []
+  type        = list(string)
+}
+
+variable "viewers_custom_role" {
+  description = "The role that should be applied. Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name}"
+  default     = ""
+  type        = string
 }
 
 variable "bucket_admins" {
@@ -92,16 +118,19 @@ variable "labels" {
 variable "set_admin_roles" {
   description = "Grant roles/storage.objectAdmin role to admins and bucket_admins."
   default     = false
+  type        = bool
 }
 
 variable "set_creator_roles" {
   description = "Grant roles/storage.objectCreator role to creators and bucket_creators."
   default     = false
+  type        = bool
 }
 
 variable "set_viewer_roles" {
   description = "Grant roles/storage.objectViewer role to viewers and bucket_viewers."
   default     = false
+  type        = bool
 }
 
 variable "lifecycle_rules" {


### PR DESCRIPTION
I have created 3 new non-required variable (`viewers_custom_role`,`creators_custom_role`,`admins_custom_role`).
With each variable, it's now possible to use a custom IAM role to replace the default role like `roles/storage.objectViewer`.

I have added "type" attribute on variables (Terraform 0.12)

I have make doc and male test defined on CONTRIBUTING.md