### PR TITLE
Add encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Functional examples are included in the
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list | `<list>` | no |
-| encryption | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
+| encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Functional examples are included in the
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list | `<list>` | no |
+| encryption | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ These sections describe requirements for using this module.
 
 The following dependencies must be available:
 
-- [Terraform][terraform] v0.11
+- [Terraform][terraform] v0.12
+  - For Terraform v0.11 see the [Compatibility](#compatibility) section above
 - [Terraform Provider for GCP][terraform-provider-gcp] plugin v2.0
 
 ### Service Account

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,23 @@ resource "google_storage_bucket" "buckets" {
       false,
     )
   }
+  # Having a permanent encryption block with default_kms_key_name = "" works but results in terraform applying a change every run
+  # There is no enabled = false attribute available to ask terraform to ignore the block
+  dynamic "encryption" {
+    # If an encryption key name is set for this bucket name -> Create a single encryption block
+    for_each = trimspace(lookup(var.encryption, lower(element(var.names, count.index)), "")) != "" ? [true] : []
+    content {
+      default_kms_key_name = trimspace(
+        lookup(
+          var.encryption,
+          lower(element(var.names, count.index)),
+          "Error retrieving kms key name", # Should be unreachable due to the for_each check
+          # Ommitted default is depricated & can help show if there was a bug
+          # https://www.terraform.io/docs/configuration/functions/lookup.html
+        )
+      )
+    }
+  }
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules
     content {

--- a/main.tf
+++ b/main.tf
@@ -46,11 +46,11 @@ resource "google_storage_bucket" "buckets" {
   # There is no enabled = false attribute available to ask terraform to ignore the block
   dynamic "encryption" {
     # If an encryption key name is set for this bucket name -> Create a single encryption block
-    for_each = trimspace(lookup(var.encryption, lower(element(var.names, count.index)), "")) != "" ? [true] : []
+    for_each = trimspace(lookup(var.encryption_key_names, lower(element(var.names, count.index)), "")) != "" ? [true] : []
     content {
       default_kms_key_name = trimspace(
         lookup(
-          var.encryption,
+          var.encryption_key_names,
           lower(element(var.names, count.index)),
           "Error retrieving kms key name", # Should be unreachable due to the for_each check
           # Omitting default is deprecated & can help show if there was a bug

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "google_storage_bucket" "buckets" {
           var.encryption,
           lower(element(var.names, count.index)),
           "Error retrieving kms key name", # Should be unreachable due to the for_each check
-          # Ommitted default is depricated & can help show if there was a bug
+          # Omitting default is deprecated & can help show if there was a bug
           # https://www.terraform.io/docs/configuration/functions/lookup.html
         )
       )

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "versioning" {
   default     = {}
 }
 
-variable "encryption" {
+variable "encryption_key_names" {
   description = "Optional map of lowercase unprefixed name => string, empty strings are ignored."
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,11 @@ variable "versioning" {
   default     = {}
 }
 
+variable "encryption" {
+  description = "Optional map of lowercase unprefixed name => string, empty strings are ignored."
+  default     = {}
+}
+
 variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   default     = {}


### PR DESCRIPTION
Resolves #27 

This PR allows for users to specify the `default_kms_key_name` attribute to enable encryption.

Encryption can be enabled on a bucket by bucket basis similar to the existing settings: `versioning` and `force_delete`

The TF handles for empty strings because while an empty string is a valid input that results in a normal google managed key bucket, terraform will see this as a change every `terraform apply`.
There is no `enable = false` attribute option to have the `encryption` block ignored.
See the bottom of the PR for an example & plan demonstrating the issue

(Also bumps the version in requirements to match the compatibility section)

---

**Example Usage:**

Here bucket `a` will have CMEK encryption and bucket `b` will have the default google managed encryption

```tf
module "gcs_buckets" {
  source     = "./some/location/terraform-google-cloud-storage"
  project_id = local.project_id
  prefix     = "test"
  names      = [ "a", "b" ]

  encryption_key_names = {
    a: data.google_kms_crypto_key.key.self_link
  }
}
```

Resulting Plan:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.gcs_buckets.google_storage_bucket.buckets[0] will be created
  + resource "google_storage_bucket" "buckets" {
      + bucket_policy_only = true
      + force_destroy      = false
      + id                 = (known after apply)
      + labels             = {
          + "name" = "test-eu-a"
        }
      + location           = "EU"
      + name               = "test-eu-a"
      + project            = "<REDACTED>"
      + self_link          = (known after apply)
      + storage_class      = "MULTI_REGIONAL"
      + url                = (known after apply)

      + encryption {
          + default_kms_key_name = "<REDACTED>"
        }

      + versioning {
          + enabled = false
        }
    }

  # module.gcs_buckets.google_storage_bucket.buckets[1] will be created
  + resource "google_storage_bucket" "buckets" {
      + bucket_policy_only = true
      + force_destroy      = false
      + id                 = (known after apply)
      + labels             = {
          + "name" = "test-eu-b"
        }
      + location           = "EU"
      + name               = "test-eu-b"
      + project            = "<REDACTED>"
      + self_link          = (known after apply)
      + storage_class      = "MULTI_REGIONAL"
      + url                = (known after apply)

      + versioning {
          + enabled = false
        }
    }
```

---

**Example of the re-apply issue:**

```tf
resource "google_storage_bucket" "bucket" {
  project  = local.project_id
  name     = "test-empty-encryption-block"
  location = "EU"

  encryption {
    default_kms_key_name = ""
  }
}
```

First plan:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_storage_bucket.bucket will be created
  + resource "google_storage_bucket" "bucket" {
      + bucket_policy_only = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + location           = "EU"
      + name               = "test-empty-encryption-block"
      + project            = "<REDACTED>"
      + self_link          = (known after apply)
      + storage_class      = "STANDARD"
      + url                = (known after apply)

      + encryption {}
    }
```

Every repeat plan:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_storage_bucket.bucket will be updated in-place
  ~ resource "google_storage_bucket" "bucket" {
        bucket_policy_only = false
        force_destroy      = false
        id                 = "test-empty-encryption-block"
        labels             = {}
        location           = "EU"
        name               = "test-empty-encryption-block"
        project            = "<REDACTED>"
        requester_pays     = false
        self_link          = "https://www.googleapis.com/storage/v1/b/test-empty-encryption-block"
        storage_class      = "STANDARD"
        url                = "gs://test-empty-encryption-block"

      + encryption {}
    }
```