### PR TITLE
Adding type constraints to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list | `<list>` | no |
+| admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list(string) | `<list>` | no |
 | bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
-| creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list | `<list>` | no |
+| creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |
@@ -60,12 +60,12 @@ Functional examples are included in the
 | names | Bucket name suffixes. | list(string) | n/a | yes |
 | prefix | Prefix used to generate the bucket name. | string | n/a | yes |
 | project\_id | Bucket project id. | string | n/a | yes |
-| set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | string | `"false"` | no |
-| set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | string | `"false"` | no |
-| set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | string | `"false"` | no |
+| set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
+| set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |
+| set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | bool | `"false"` | no |
 | storage\_class | Bucket storage class. | string | `"MULTI_REGIONAL"` | no |
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
-| viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | list | `<list>` | no |
+| viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | list(string) | `<list>` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,100 +31,100 @@ variable "names" {
 
 variable "location" {
   description = "Bucket location."
-  default     = "EU"
   type        = string
+  default     = "EU"
 }
 
 variable "storage_class" {
   description = "Bucket storage class."
-  default     = "MULTI_REGIONAL"
   type        = string
+  default     = "MULTI_REGIONAL"
 }
 
 variable "force_destroy" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "versioning" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "encryption_key_names" {
   description = "Optional map of lowercase unprefixed name => string, empty strings are ignored."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "admins" {
   description = "IAM-style members who will be granted roles/storage.objectAdmin on all buckets."
-  default     = []
   type        = list(string)
+  default     = []
 }
 
 variable "creators" {
   description = "IAM-style members who will be granted roles/storage.objectCreators on all buckets."
-  default     = []
   type        = list(string)
+  default     = []
 }
 
 variable "viewers" {
   description = "IAM-style members who will be granted roles/storage.objectViewer on all buckets."
-  default     = []
   type        = list(string)
+  default     = []
 }
 
 variable "bucket_admins" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "bucket_creators" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "bucket_viewers" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers."
-  default     = {}
   type        = map
+  default     = {}
 }
 
 variable "labels" {
   description = "Labels to be attached to the buckets"
-  default     = {}
   type        = map
+  default     = {}
 }
 
 # we need flags to allow member lists to contain dynamic elements
 
 variable "set_admin_roles" {
   description = "Grant roles/storage.objectAdmin role to admins and bucket_admins."
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "set_creator_roles" {
   description = "Grant roles/storage.objectCreator role to creators and bucket_creators."
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "set_viewer_roles" {
   description = "Grant roles/storage.objectViewer role to viewers and bucket_viewers."
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "lifecycle_rules" {
@@ -136,6 +136,6 @@ variable "lifecycle_rules" {
     condition = map(string)
   }))
   description = "List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string."
-  default     = []
   type        = list(string)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,10 +16,12 @@
 
 variable "project_id" {
   description = "Bucket project id."
+  type        = string
 }
 
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
+  type        = string
 }
 
 variable "names" {
@@ -30,66 +32,79 @@ variable "names" {
 variable "location" {
   description = "Bucket location."
   default     = "EU"
+  type        = string
 }
 
 variable "storage_class" {
   description = "Bucket storage class."
   default     = "MULTI_REGIONAL"
+  type        = string
 }
 
 variable "force_destroy" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
   default     = {}
+  type        = map
 }
 
 variable "versioning" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
   default     = {}
+  type        = map
 }
 
 variable "encryption_key_names" {
   description = "Optional map of lowercase unprefixed name => string, empty strings are ignored."
   default     = {}
+  type        = map
 }
 
 variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   default     = {}
+  type        = map
 }
 
 variable "admins" {
   description = "IAM-style members who will be granted roles/storage.objectAdmin on all buckets."
   default     = []
+  type        = list(string)
 }
 
 variable "creators" {
   description = "IAM-style members who will be granted roles/storage.objectCreators on all buckets."
   default     = []
+  type        = list(string)
 }
 
 variable "viewers" {
   description = "IAM-style members who will be granted roles/storage.objectViewer on all buckets."
   default     = []
+  type        = list(string)
 }
 
 variable "bucket_admins" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins."
   default     = {}
+  type        = map
 }
 
 variable "bucket_creators" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators."
   default     = {}
+  type        = map
 }
 
 variable "bucket_viewers" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers."
   default     = {}
+  type        = map
 }
 
 variable "labels" {
   description = "Labels to be attached to the buckets"
   default     = {}
+  type        = map
 }
 
 # we need flags to allow member lists to contain dynamic elements
@@ -97,16 +112,19 @@ variable "labels" {
 variable "set_admin_roles" {
   description = "Grant roles/storage.objectAdmin role to admins and bucket_admins."
   default     = false
+  type        = bool
 }
 
 variable "set_creator_roles" {
   description = "Grant roles/storage.objectCreator role to creators and bucket_creators."
   default     = false
+  type        = bool
 }
 
 variable "set_viewer_roles" {
   description = "Grant roles/storage.objectViewer role to viewers and bucket_viewers."
   default     = false
+  type        = bool
 }
 
 variable "lifecycle_rules" {
@@ -117,6 +135,7 @@ variable "lifecycle_rules" {
     })
     condition = map(string)
   }))
-  default     = []
   description = "List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string."
+  default     = []
+  type        = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,5 @@ variable "lifecycle_rules" {
     condition = map(string)
   }))
   description = "List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string."
-  type        = list(string)
   default     = []
 }


### PR DESCRIPTION
For best practices and for users who implement terragrunt [0]. Type constrains should be added [1]. Without specifying these constraints, applying a terragrunt plan/apply results in type errors [2], depending on the type constraints.

In terragrunt, "values are being passed in with environment variables and json, the type information is lost when crossing the boundary between Terragrunt and Terraform. You must specify the proper type constraint on the variable in Terraform in order for Terraform to process the inputs to the right type" [3].


tl;dr lists and maps currently do not work with terragrunt because type constraints are not explicitly set.


[0] https://github.com/gruntwork-io/terragrunt
[1] https://www.terraform.io/docs/configuration/variables.html#type-constraints
[2] Invalid value for "inputMap" parameter: lookup() requires a map as the first
argument.
[3] https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#inputs
