### PR TITLE
Feature/top folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Functional examples are included in the
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
+| folders | Map of lowercase unprefixed name => list of top level folder objects. | map | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | labels | Labels to be attached to the buckets | map | `<map>` | no |
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |

--- a/examples/multiple_buckets/README.md
+++ b/examples/multiple_buckets/README.md
@@ -8,6 +8,7 @@ This example illustrates how to use the `cloud-storage` module.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map(string) | n/a | yes |
+| folders | Top level bucket folders. Map of lowercase unprefixed name => list of folders to create. | map | n/a | yes |
 | names | Names of the buckets to create. | list(string) | n/a | yes |
 | prefix | Prefix used to generate bueckt names. | string | n/a | yes |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -24,6 +24,7 @@ module "cloud_storage" {
   prefix             = var.prefix
   names              = var.names
   bucket_policy_only = var.bucket_policy_only
+  folders            = var.folders
 
   lifecycle_rules = [{
     action = {

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -33,3 +33,8 @@ variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   type        = map(string)
 }
+
+variable "folders" {
+  description = "Top level bucket folders. Map of lowercase unprefixed name => list of folders to create."
+  type        = map
+}

--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,6 @@ resource "google_storage_bucket_iam_binding" "viewers" {
 resource "google_storage_bucket_object" "folders" {
   for_each = { for obj in local.folder_list : "${obj.bucket}_${obj.folder}" => obj }
   bucket   = element(google_storage_bucket.buckets.*.name, index(var.names, each.value.bucket))
-  name     = "${each.value.folder}/"
-  content  = "none"
+  name     = "${each.value.folder}/" # Declaring an object with a trailing '/' creates a directory
+  content  = "foo"                   # Note that the content string isn't actually used, but is only there since the resource requires it
 }

--- a/test/fixtures/multiple_buckets/main.tf
+++ b/test/fixtures/multiple_buckets/main.tf
@@ -29,6 +29,9 @@ module "example" {
   project_id = var.project_id
   prefix     = "multiple-buckets-${random_string.prefix.result}"
   names      = ["one", "two"]
+  folders = {
+    "two" = ["dev", "prod"]
+  }
 
   bucket_policy_only = {
     "one" = true

--- a/test/integration/multiple_buckets/controls/gsutil.rb
+++ b/test/integration/multiple_buckets/controls/gsutil.rb
@@ -24,6 +24,13 @@ control "gsutil" do
     its(:stdout) { should include attribute('names').values[1] }
   end
 
+  describe command("gsutil ls gs://#{attribute("names_list")[1]}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    its(:stdout) { should include "gs://#{attribute("names_list")[1]}/dev/" }
+    its(:stdout) { should include "gs://#{attribute("names_list")[1]}/prod/" }
+  end
+
   describe command("gsutil bucketpolicyonly get gs://#{attribute("names_list")[0]}") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "labels" {
   default     = {}
 }
 
+variable "folders" {
+  description = "Map of lowercase unprefixed name => list of top level folder objects."
+  type        = map
+  default     = {}
+}
+
 # we need flags to allow member lists to contain dynamic elements
 
 variable "set_admin_roles" {


### PR DESCRIPTION
Fixes #46 

Feature: Create top level folders in GCS buckets
Usage: `var.folders` is a map of lowercase unprefixed name => list of top level folder objects.
```
  folders = {
    "two" = ["dev", "prod"]
  }
```