### PR TITLE
add support for cors and  website blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Functional examples are included in the
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
-| prefix | Prefix used to generate the bucket name. | string | `""` | no |
+| prefix | Prefix used to generate the bucket name. | string | n/a | yes |
 | project\_id | Bucket project id. | string | n/a | yes |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Functional examples are included in the
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
+| cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
@@ -58,7 +59,7 @@ Functional examples are included in the
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
-| prefix | Prefix used to generate the bucket name. | string | n/a | yes |
+| prefix | Prefix used to generate the bucket name. | string | `""` | no |
 | project\_id | Bucket project id. | string | n/a | yes |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |
@@ -66,6 +67,7 @@ Functional examples are included in the
 | storage\_class | Bucket storage class. | string | `"MULTI_REGIONAL"` | no |
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | list(string) | `<list>` | no |
+| website | Map of website values. Supported attributes: main_page_suffix, not_found_page | any | `<map>` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,23 @@ resource "google_storage_bucket" "buckets" {
       )
     }
   }
+  dynamic "cors" {
+    for_each = lookup(var.cors, element(var.names, count.index), {}) != {} ? { v = lookup(var.cors, element(var.names, count.index)) } : {}
+    content {
+      origin          = lookup(cors.value, "origin", null)
+      method          = lookup(cors.value, "method", null)
+      response_header = lookup(cors.value, "response_header", null)
+      max_age_seconds = lookup(cors.value, "max_age_seconds", null)
+    }
+  }
+  dynamic "website" {
+    for_each = lookup(var.website, element(var.names, count.index), {}) != {} ? { v = lookup(var.website, element(var.names, count.index)) } : {}
+    content {
+      main_page_suffix = lookup(website.value, "main_page_suffix", null)
+      not_found_page   = lookup(website.value, "not_found_page", null)
+    }
+  }
+
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,6 @@ variable "project_id" {
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
   type        = string
-  default     = ""
 }
 
 variable "names" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "project_id" {
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
   type        = string
+  default     = ""
 }
 
 variable "names" {
@@ -144,4 +145,16 @@ variable "lifecycle_rules" {
   }))
   description = "List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string."
   default     = []
+}
+
+variable "cors" {
+  description = "Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors"
+  type        = any
+  default     = {}
+}
+
+variable "website" {
+  type        = any
+  default     = {}
+  description = "Map of website values. Supported attributes: main_page_suffix, not_found_page"
 }


### PR DESCRIPTION
This PR adds support for the `cors` and `website` attribute blocks.
These are needed for managing buckets to be used as static sites.

https://www.terraform.io/docs/providers/google/r/storage_bucket.html#example-usage-creating-a-private-bucket-in-standard-storage-in-the-eu-region-bucket-configured-as-static-website-and-cors-configurations

I had to define the variables as `type = any` due to this issue: https://github.com/hashicorp/terraform/issues/19898

~I've also updated the `prefix` variable to have a default of an empty string. Which should be a nicer experience then having to explicitly set the attribute to an empty string as part of module inputs if you don't want a prefix and location info pre-pended to the bucket name.
Should make experiences like this a little cleaner: https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/12~