### PR TITLE
chore: Simplify example setup

### DIFF
--- a/examples/multiple_buckets/README.md
+++ b/examples/multiple_buckets/README.md
@@ -7,10 +7,9 @@ This example illustrates how to use the `cloud-storage` module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map(string) | n/a | yes |
-| folders | Top level bucket folders. Map of lowercase unprefixed name => list of folders to create. | map | n/a | yes |
-| names | Names of the buckets to create. | list(string) | n/a | yes |
-| prefix | Prefix used to generate bueckt names. | string | n/a | yes |
+| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map(string) | `<map>` | no |
+| folders | Top level bucket folders. Map of lowercase unprefixed name => list of folders to create. | map | `<map>` | no |
+| names | Names of the buckets to create. | list(string) | `<list>` | no |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
 
 ## Outputs

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -25,9 +25,9 @@ resource "random_string" "prefix" {
 }
 
 module "cloud_storage" {
-  source             = "../.."
-  project_id         = var.project_id
-  prefix             = "multiple-buckets-${random_string.prefix.result}"
+  source     = "../.."
+  project_id = var.project_id
+  prefix     = "multiple-buckets-${random_string.prefix.result}"
 
   names              = var.names
   bucket_policy_only = var.bucket_policy_only

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -18,10 +18,17 @@ provider "google" {
   version = "~> 2.18.0"
 }
 
+resource "random_string" "prefix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
 module "cloud_storage" {
   source             = "../.."
   project_id         = var.project_id
-  prefix             = var.prefix
+  prefix             = "multiple-buckets-${random_string.prefix.result}"
+
   names              = var.names
   bucket_policy_only = var.bucket_policy_only
   folders            = var.folders

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -22,7 +22,7 @@ variable "project_id" {
 variable "names" {
   description = "Names of the buckets to create."
   type        = list(string)
-  default     = ["one"]
+  default     = ["one", "see"]
 }
 
 variable "bucket_policy_only" {

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -22,7 +22,7 @@ variable "project_id" {
 variable "names" {
   description = "Names of the buckets to create."
   type        = list(string)
-  default     = ["one", "see"]
+  default     = ["one", "two"]
 }
 
 variable "bucket_policy_only" {

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -22,19 +22,17 @@ variable "project_id" {
 variable "names" {
   description = "Names of the buckets to create."
   type        = list(string)
-}
-
-variable "prefix" {
-  description = "Prefix used to generate bueckt names."
-  type        = string
+  default     = ["one"]
 }
 
 variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   type        = map(string)
+  default     = {}
 }
 
 variable "folders" {
   description = "Top level bucket folders. Map of lowercase unprefixed name => list of folders to create."
   type        = map
+  default     = {}
 }

--- a/test/fixtures/multiple_buckets/main.tf
+++ b/test/fixtures/multiple_buckets/main.tf
@@ -21,7 +21,7 @@ provider "random" {
 module "example" {
   source     = "../../../examples/multiple_buckets"
   project_id = var.project_id
-  names      = ["one", "two"]
+
   folders = {
     "two" = ["dev", "prod"]
   }

--- a/test/fixtures/multiple_buckets/main.tf
+++ b/test/fixtures/multiple_buckets/main.tf
@@ -18,16 +18,9 @@ provider "random" {
   version = "~> 2.0"
 }
 
-resource "random_string" "prefix" {
-  length  = 4
-  upper   = false
-  special = false
-}
-
 module "example" {
   source     = "../../../examples/multiple_buckets"
   project_id = var.project_id
-  prefix     = "multiple-buckets-${random_string.prefix.result}"
   names      = ["one", "two"]
   folders = {
     "two" = ["dev", "prod"]


### PR DESCRIPTION
For examples, we should try to only require project ID.