### PR TITLE
Allow legacy roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Functional examples are included in the
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
-| prefix | Prefix used to generate the bucket name. | string | n/a | yes |
+| prefix | Prefix used to generate the bucket name. | string | `""` | no |
 | project\_id | Bucket project id. | string | n/a | yes |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Functional examples are included in the
 | bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
+| bucket\_readers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket legacy readers. | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
@@ -62,8 +63,10 @@ Functional examples are included in the
 | names | Bucket name suffixes. | list(string) | n/a | yes |
 | prefix | Prefix used to generate the bucket name. | string | `""` | no |
 | project\_id | Bucket project id. | string | n/a | yes |
+| readers | IAM-style members who will be granted roles/storage.legacyObjectReader on all buckets. | list(string) | `<list>` | no |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |
+| set\_reader\_roles | Grant roles/storage.legacyObjectReader role to readers and bucket_readers. | bool | `"false"` | no |
 | set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | bool | `"false"` | no |
 | storage\_class | Bucket storage class. | string | `"MULTI_REGIONAL"` | no |
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Functional examples are included in the
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
-| prefix | Prefix used to generate the bucket name. | string | `""` | no |
+| prefix | Prefix used to generate the bucket name. | string | n/a | yes |
 | project\_id | Bucket project id. | string | n/a | yes |
 | readers | IAM-style members who will be granted roles/storage.legacyObjectReader on all buckets. | list(string) | `<list>` | no |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |

--- a/examples/static_site_bucket/README.md
+++ b/examples/static_site_bucket/README.md
@@ -1,0 +1,27 @@
+# Simple Example
+
+This example illustrates how to use the `cloud-storage` module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| names\_list | Names of the buckets to create. | list(string) | `<list>` | no |
+| prefix | Prefix used to generate bucket names. | string | `""` | no |
+| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| names | Bucket names. |
+| names\_list | List of bucket names. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/static_site_bucket/README.md
+++ b/examples/static_site_bucket/README.md
@@ -7,9 +7,14 @@ This example illustrates how to use the `cloud-storage` module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bucket\_readers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket legacy readers. | map | `<map>` | no |
+| cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
+| names | Bucket name suffixes. | list(string) | n/a | yes |
 | names\_list | Names of the buckets to create. | list(string) | `<list>` | no |
 | prefix | Prefix used to generate bucket names. | string | `""` | no |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+| set\_reader\_roles | Grant roles/storage.legacyObjectReader role to readers and bucket_readers. | bool | `"false"` | no |
+| website | Map of website values. Supported attributes: main_page_suffix, not_found_page | any | `<map>` | no |
 
 ## Outputs
 

--- a/examples/static_site_bucket/main.tf
+++ b/examples/static_site_bucket/main.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 2.18.0"
+}
+
+
+##This should actually be a legitimate FQDN.
+##Using a random name here due to domain ownership verification requirements
+## https://cloud.google.com/storage/docs/domain-name-verification#requirements
+
+locals {
+  fqdn = "example-${random_string.suffix.result}"
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+module "static_site" {
+  source           = "../.."
+  project_id       = var.project_id
+  prefix           = ""
+  names            = [local.fqdn]
+  set_reader_roles = true
+
+  bucket_readers = {
+    "${local.fqdn}" = "allUsers"
+  }
+
+  website = {
+    "${local.fqdn}" = {
+      main_page_suffix = "index.html"
+      not_found_page   = "404.html"
+    },
+  }
+
+  cors = {
+    "${local.fqdn}" = {
+      origin          = ["http://${local.fqdn}"]
+      method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+      response_header = ["*"]
+      max_age_seconds = 3600
+    },
+  }
+
+
+}

--- a/examples/static_site_bucket/outputs.tf
+++ b/examples/static_site_bucket/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "names" {
+  description = "Bucket names."
+  value       = module.static_site.names
+}
+
+output "names_list" {
+  description = "List of bucket names."
+  value       = module.static_site.names_list
+}

--- a/examples/static_site_bucket/variables.tf
+++ b/examples/static_site_bucket/variables.tf
@@ -30,3 +30,33 @@ variable "prefix" {
   type        = string
   default     = ""
 }
+
+variable "names" {
+  description = "Bucket name suffixes."
+  type        = list(string)
+}
+
+variable "set_reader_roles" {
+  description = "Grant roles/storage.legacyObjectReader role to readers and bucket_readers."
+  type        = bool
+  default     = false
+}
+
+variable "bucket_readers" {
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket legacy readers."
+  type        = map
+  default     = {}
+}
+
+variable "website" {
+  type        = any
+  default     = {}
+  description = "Map of website values. Supported attributes: main_page_suffix, not_found_page"
+}
+
+variable "cors" {
+  description = "Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors"
+  type        = any
+  default     = {}
+}
+

--- a/examples/static_site_bucket/variables.tf
+++ b/examples/static_site_bucket/variables.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "names_list" {
+  description = "Names of the buckets to create."
+  type        = list(string)
+  default     = ["example.com"]
+}
+
+variable "prefix" {
+  description = "Prefix used to generate bucket names."
+  type        = string
+  default     = ""
+}

--- a/examples/static_site_bucket/versions.tf
+++ b/examples/static_site_bucket/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -36,3 +36,13 @@ suites:
           backend: local
           controls:
             - gsutil
+  - name: static_site_bucket
+    driver:
+      root_module_directory: test/fixtures/static_site_bucket/
+    verifier:
+      color: false
+      systems:
+        - name: static_site_bucket local
+          backend: local
+          controls:
+            - gsutil

--- a/test/fixtures/static_site_bucket/main.tf
+++ b/test/fixtures/static_site_bucket/main.tf
@@ -18,9 +18,41 @@ provider "random" {
   version = "~> 2.0"
 }
 
+locals {
+  fqdn = "example-${random_string.suffix.result}"
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
 
 module "example" {
-  source     = "../../../examples/static_site_bucket"
-  project_id = var.project_id
-  prefix     = ""
+  source           = "../../../examples/static_site_bucket"
+  project_id       = var.project_id
+  prefix           = ""
+  names            = [local.fqdn]
+  set_reader_roles = true
+
+  bucket_readers = {
+    "${local.fqdn}" = "allUsers"
+  }
+
+  website = {
+    "${local.fqdn}" = {
+      main_page_suffix = "index.html"
+      not_found_page   = "404.html"
+    },
+  }
+
+  cors = {
+    "${local.fqdn}" = {
+      origin          = ["http://${local.fqdn}"]
+      method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+      response_header = ["*"]
+      max_age_seconds = 3600
+    },
+  }
+
 }

--- a/test/fixtures/static_site_bucket/main.tf
+++ b/test/fixtures/static_site_bucket/main.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+
+module "example" {
+  source     = "../../../examples/static_site_bucket"
+  project_id = var.project_id
+  prefix     = ""
+}

--- a/test/fixtures/static_site_bucket/outputs.tf
+++ b/test/fixtures/static_site_bucket/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "names" {
+  description = "Bucket names."
+  value       = module.example.names
+}
+
+output "names_list" {
+  description = "List of bucket names."
+  value       = module.example.names_list
+}
+
+output "project_id" {
+  description = "The ID of the project in which resources are provisioned."
+  value       = var.project_id
+}
+

--- a/test/fixtures/static_site_bucket/variables.tf
+++ b/test/fixtures/static_site_bucket/variables.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "names_list" {
+  description = "Names of the buckets to create."
+  type        = list(string)
+  default     = ["example.com"]
+}
+
+variable "prefix" {
+  description = "Prefix used to generate bucket names."
+  type        = string
+  default     = ""
+}

--- a/test/fixtures/static_site_bucket/versions.tf
+++ b/test/fixtures/static_site_bucket/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/test/integration/static_site_bucket/controls/gsutil.rb
+++ b/test/integration/static_site_bucket/controls/gsutil.rb
@@ -1,0 +1,56 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+
+control "gsutil" do
+  title "gsutil"
+
+  describe command("gsutil ls -p #{attribute("project_id")}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    its(:stdout) { should include attribute('names_list')[0] }
+  end
+
+  get_bucket_0_cors = command("gsutil cors get gs://#{attribute("names_list")[0]}")
+  describe get_bucket_0_cors do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+  end
+
+  describe command("gsutil iam get gs://#{attribute("names_list")[0]}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+   describe "allUsers" do
+     it "allUsers is roles/storage.legacyObjectReader" do
+       expect(data['bindings']).to include(
+         including(
+           "members" => ["allUsers"],
+           "role" => "roles/storage.legacyObjectReader"
+         )
+       )
+     end
+   end
+  end
+
+end

--- a/test/integration/static_site_bucket/controls/gsutil.rb
+++ b/test/integration/static_site_bucket/controls/gsutil.rb
@@ -23,10 +23,30 @@ control "gsutil" do
     its(:stdout) { should include attribute('names_list')[0] }
   end
 
-  get_bucket_0_cors = command("gsutil cors get gs://#{attribute("names_list")[0]}")
-  describe get_bucket_0_cors do
+  describe command("gsutil cors get gs://#{attribute("names_list")[0]}") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }
+  end
+
+  describe command("gsutil web get gs://#{attribute("names_list")[0]}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+   describe "website" do
+     it "website set index.html and 404.html" do
+       expect(data).to include(
+         "mainPageSuffix" => "index.html",
+         "notFoundPage" => "404.html"
+         )
+     end
+   end
   end
 
   describe command("gsutil iam get gs://#{attribute("names_list")[0]}") do
@@ -54,3 +74,4 @@ control "gsutil" do
   end
 
 end
+

--- a/test/integration/static_site_bucket/inspec.yml
+++ b/test/integration/static_site_bucket/inspec.yml
@@ -1,0 +1,10 @@
+name: static_site_bucket
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: names
+    required: true
+    type: hash
+  - name: names_list
+    type: array

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "project_id" {
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
   type        = string
+  default     = ""
 }
 
 variable "names" {

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "viewers" {
   default     = []
 }
 
+variable "readers" {
+  description = "IAM-style members who will be granted roles/storage.legacyObjectReader on all buckets."
+  type        = list(string)
+  default     = []
+}
+
 variable "bucket_admins" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins."
   type        = map
@@ -101,6 +107,13 @@ variable "bucket_viewers" {
   type        = map
   default     = {}
 }
+
+variable "bucket_readers" {
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket legacy readers."
+  type        = map
+  default     = {}
+}
+
 
 variable "labels" {
   description = "Labels to be attached to the buckets"
@@ -134,6 +147,11 @@ variable "set_viewer_roles" {
   default     = false
 }
 
+variable "set_reader_roles" {
+  description = "Grant roles/storage.legacyObjectReader role to readers and bucket_readers."
+  type        = bool
+  default     = false
+}
 variable "lifecycle_rules" {
   type = set(object({
     # Object with keys:

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,6 @@ variable "project_id" {
 variable "prefix" {
   description = "Prefix used to generate the bucket name."
   type        = string
-  default     = ""
 }
 
 variable "names" {
@@ -152,6 +151,7 @@ variable "set_reader_roles" {
   type        = bool
   default     = false
 }
+
 variable "lifecycle_rules" {
   type = set(object({
     # Object with keys:


### PR DESCRIPTION
This allow setting the legacy  `roles/storage.legacyObjectReader` for buckets. This is useful as noted in the [documentation here ](https://cloud.google.com/storage/docs/hosting-static-website#sharing).  Also added an example and tests for serving a static site from bucket.