### PR TITLE
feat: Use uniform_bucket_level_access instead due to deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following dependencies must be available:
 
 - [Terraform][terraform] v0.12
   - For Terraform v0.11 see the [Compatibility](#compatibility) section above
-- [Terraform Provider for GCP][terraform-provider-gcp] plugin v2.0
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v3.0
 
 ### Service Account
 

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.38.0"
 }
 
 resource "random_string" "prefix" {

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "google_storage_bucket" "buckets" {
     lower(element(var.names, count.index)),
     false,
   )
-  bucket_policy_only = lookup(
+  uniform_bucket_level_access = lookup(
     var.bucket_policy_only,
     lower(element(var.names, count.index)),
     true,

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -15,13 +15,13 @@
  */
 
 resource "google_storage_bucket" "bucket" {
-  name               = var.name
-  project            = var.project_id
-  location           = var.location
-  storage_class      = var.storage_class
-  bucket_policy_only = var.bucket_policy_only
-  labels             = var.labels
-  force_destroy      = var.force_destroy
+  name                        = var.name
+  project                     = var.project_id
+  location                    = var.location
+  storage_class               = var.storage_class
+  uniform_bucket_level_access = var.bucket_policy_only
+  labels                      = var.labels
+  force_destroy               = var.force_destroy
 
   versioning {
     enabled = var.versioning

--- a/test/integration/multiple_buckets/controls/gsutil.rb
+++ b/test/integration/multiple_buckets/controls/gsutil.rb
@@ -55,7 +55,6 @@ control "gsutil" do
     it { expect(action['storageClass']).to eq("NEARLINE") }
     it { expect(action['type']).to eq("SetStorageClass") }
     it { expect(condition['age']).to eq(10) }
-    it { expect(condition['isLive']).to eq(false) }
     it { expect(condition['matchesStorageClass']).to eq(%w(MULTI_REGIONAL STANDARD DURABLE_REDUCED_AVAILABILITY)) }
   end
 
@@ -71,7 +70,6 @@ control "gsutil" do
     it { expect(action['storageClass']).to eq("NEARLINE") }
     it { expect(action['type']).to eq("SetStorageClass") }
     it { expect(condition['age']).to eq(10) }
-    it { expect(condition['isLive']).to eq(false) }
     it { expect(condition['matchesStorageClass']).to eq(%w(MULTI_REGIONAL STANDARD DURABLE_REDUCED_AVAILABILITY)) }
   end
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 9.0.0"
 
   name              = "ci-cloud-storage"
   random_project_id = "true"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.38.0"
 }
 
 terraform {


### PR DESCRIPTION
Google has deprecated the field `bucket_policy_only` in favor
of `uniform_bucket_level_access` and `bucket_policy_only`
will be removed in the next major release of the provider

Updated project-factory module in setup/main.tf
because v3 doesn't work with GCP provider v3.38.0

Resolves https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/79