### PR TITLE
Updates deprecated bucket resource input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,8 +38,8 @@ resource "google_storage_bucket" "buckets" {
     lower(element(var.names, count.index)),
     false,
   )
-  bucket_policy_only = lookup(
-    var.bucket_policy_only,
+  uniform_bucket_level_access = lookup(
+    coalesce(var.uniform_bucket_level_access, var.bucket_policy_only),
     lower(element(var.names, count.index)),
     true,
   )

--- a/variables.tf
+++ b/variables.tf
@@ -60,9 +60,15 @@ variable "encryption_key_names" {
 }
 
 variable "bucket_policy_only" {
-  description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
+  description = "Deprecated. Use uniform_bucket_level_access. Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   type        = map
   default     = {}
+}
+
+variable "uniform_bucket_level_access" {
+  description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
+  type        = map
+  default     = null
 }
 
 variable "admins" {


### PR DESCRIPTION
1. Modifies the bucket resource input to suppress deprecation warning.
2. Adds a new variable to clearly reflect the new input's name.
3. Coalesces new and old input names and sets new variable default to null to ensure backward compatibility.