### PR TITLE
Use `uniform_bucket_level_access` instead of `deprecated bucket_policy_only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Functional examples are included in the
 | admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list(string) | `<list>` | no |
 | bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
 | bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
-| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
+| uniform\_bucket\_level\_access | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
 | cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -29,9 +29,9 @@ module "cloud_storage" {
   project_id = var.project_id
   prefix     = "multiple-buckets-${random_string.prefix.result}"
 
-  names              = var.names
-  bucket_policy_only = var.bucket_policy_only
-  folders            = var.folders
+  names                       = var.names
+  uniform_bucket_level_access = var.uniform_bucket_level_access
+  folders                     = var.folders
 
   lifecycle_rules = [{
     action = {

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -25,7 +25,7 @@ variable "names" {
   default     = ["one", "two"]
 }
 
-variable "bucket_policy_only" {
+variable "uniform_bucket_level_access" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   type        = map(string)
   default     = {}

--- a/main.tf
+++ b/main.tf
@@ -38,8 +38,8 @@ resource "google_storage_bucket" "buckets" {
     lower(element(var.names, count.index)),
     false,
   )
-  bucket_policy_only = lookup(
-    var.bucket_policy_only,
+  uniform_bucket_level_access = lookup(
+    var.uniform_bucket_level_access,
     lower(element(var.names, count.index)),
     true,
   )

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "bucket" {
   project            = var.project_id
   location           = var.location
   storage_class      = var.storage_class
-  bucket_policy_only = var.bucket_policy_only
+  uniform_bucket_level_access = var.uniform_bucket_level_access
   labels             = var.labels
   force_destroy      = var.force_destroy
 

--- a/modules/simple_bucket/variables.tf
+++ b/modules/simple_bucket/variables.tf
@@ -42,8 +42,8 @@ variable "labels" {
 }
 
 
-variable "bucket_policy_only" {
-  description = "Enables Bucket Policy Only access to a bucket."
+variable "uniform_bucket_level_access" {
+  description = "Enables Uniform bucket-level access to a bucket."
   type        = bool
   default     = true
 }

--- a/test/fixtures/multiple_buckets/main.tf
+++ b/test/fixtures/multiple_buckets/main.tf
@@ -26,7 +26,7 @@ module "example" {
     "two" = ["dev", "prod"]
   }
 
-  bucket_policy_only = {
+  uniform_bucket_level_access = {
     "one" = true
     "two" = false
   }

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "encryption_key_names" {
   default     = {}
 }
 
-variable "bucket_policy_only" {
+variable "uniform_bucket_level_access" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
   type        = map
   default     = {}


### PR DESCRIPTION
Resolves https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/79