### PR TITLE
use for_each instead of count to create resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Functional examples are included in the
 | Name | Description |
 |------|-------------|
 | bucket | Bucket resource (for single use). |
-| buckets | Bucket resources. |
+| buckets | Bucket resources as list. |
+| buckets\_map | Bucket resources by name. |
 | name | Bucket name (for single use). |
 | names | Bucket names. |
 | names\_list | List of bucket names. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,40 +16,49 @@
 
 output "bucket" {
   description = "Bucket resource (for single use)."
-  value       = google_storage_bucket.buckets[0]
+  value       = local.first_bucket
 }
 
 output "name" {
   description = "Bucket name (for single use)."
-  value       = google_storage_bucket.buckets[0].name
+  value       = local.first_bucket.name
 }
 
 output "url" {
   description = "Bucket URL (for single use)."
-  value       = google_storage_bucket.buckets[0].url
+  value       = local.first_bucket.url
 }
 
 output "buckets" {
-  description = "Bucket resources."
+  description = "Bucket resources as list."
+  value       = local.buckets_list
+}
+
+output "buckets_map" {
+  description = "Bucket resources by name."
   value       = google_storage_bucket.buckets
 }
 
 output "names" {
   description = "Bucket names."
-  value       = zipmap(var.names, slice(google_storage_bucket.buckets[*].name, 0, length(var.names)))
+  value = { for name, bucket in google_storage_bucket.buckets :
+    name => bucket.name
+  }
 }
 
 output "urls" {
   description = "Bucket URLs."
-  value       = zipmap(var.names, slice(google_storage_bucket.buckets[*].url, 0, length(var.names)))
+  value = { for name, bucket in google_storage_bucket.buckets :
+    name => bucket.url
+  }
 }
 
 output "names_list" {
   description = "List of bucket names."
-  value       = google_storage_bucket.buckets[*].name
+  value       = local.buckets_list[*].name
 }
 
 output "urls_list" {
   description = "List of bucket URLs."
-  value       = google_storage_bucket.buckets[*].url
+  value       = local.buckets_list[*].url
 }


### PR DESCRIPTION
This prevents unnencesary recreation of resources when content/order of the
names list changes.

Addresses issue mentioned in: https://github.com/terraform-google-modules/cloud-foundation-fabric/tree/73b7613cc062491305ebfabf8a8b1db0c53fc55b/foundations#things-to-be-aware-of