### PR TITLE
allow setting storage.admin and storage.hmacKeyAdmin roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.10.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,19 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | admins | IAM-style members who will be granted roles/storage.objectAdmin on all buckets. | list(string) | `<list>` | no |
-| bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins. | map | `<map>` | no |
-| bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators. | map | `<map>` | no |
-| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map | `<map>` | no |
-| bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers. | map | `<map>` | no |
+| bucket\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket admins. | map(string) | `<map>` | no |
+| bucket\_creators | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket creators. | map(string) | `<map>` | no |
+| bucket\_hmac\_key\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket HMAC Key admins. | map(string) | `<map>` | no |
+| bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | map(bool) | `<map>` | no |
+| bucket\_storage\_admins | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket storage admins. | map(string) | `<map>` | no |
+| bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers. | map(string) | `<map>` | no |
 | cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
-| encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map | `<map>` | no |
-| folders | Map of lowercase unprefixed name => list of top level folder objects. | map | `<map>` | no |
-| force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
-| labels | Labels to be attached to the buckets | map | `<map>` | no |
+| encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map(string) | `<map>` | no |
+| folders | Map of lowercase unprefixed name => list of top level folder objects. | map(string) | `<map>` | no |
+| force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map(bool) | `<map>` | no |
+| hmac\_key\_admins | IAM-style members who will be granted roles/storage.hmacKeyAdmin on all buckets. | list(string) | `<list>` | no |
+| labels | Labels to be attached to the buckets | map(string) | `<map>` | no |
 | lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string. | object | `<list>` | no |
 | location | Bucket location. | string | `"EU"` | no |
 | names | Bucket name suffixes. | list(string) | n/a | yes |
@@ -64,9 +67,12 @@ Functional examples are included in the
 | project\_id | Bucket project id. | string | n/a | yes |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket_admins. | bool | `"false"` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket_creators. | bool | `"false"` | no |
+| set\_hmac\_key\_admin\_roles | Grant roles/storage.hmacKeyAdmin role to hmac_key_admins and bucket_hmac_key_admins. | bool | `"false"` | no |
+| set\_storage\_admin\_roles | Grant roles/storage.admin role to storage_admins and bucket_storage_admins. | bool | `"false"` | no |
 | set\_viewer\_roles | Grant roles/storage.objectViewer role to viewers and bucket_viewers. | bool | `"false"` | no |
+| storage\_admins | IAM-style members who will be granted roles/storage.admin on all buckets. | list(string) | `<list>` | no |
 | storage\_class | Bucket storage class. | string | `"MULTI_REGIONAL"` | no |
-| versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map | `<map>` | no |
+| versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | map(bool) | `<map>` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | list(string) | `<list>` | no |
 | website | Map of website values. Supported attributes: main_page_suffix, not_found_page | any | `<map>` | no |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Functional examples are included in the
 | cors | Map of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | any | `<map>` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | list(string) | `<list>` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | map(string) | `<map>` | no |
-| folders | Map of lowercase unprefixed name => list of top level folder objects. | map(string) | `<map>` | no |
+| folders | Map of lowercase unprefixed name => list of top level folder objects. | map(list(string)) | `<map>` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | map(bool) | `<map>` | no |
 | hmac\_key\_admins | IAM-style members who will be granted roles/storage.hmacKeyAdmin on all buckets. | list(string) | `<list>` | no |
 | labels | Labels to be attached to the buckets | map(string) | `<map>` | no |

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -41,4 +41,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,36 @@ resource "google_storage_bucket_iam_binding" "viewers" {
   )
 }
 
+resource "google_storage_bucket_iam_binding" "hmac_key_admins" {
+  for_each = var.set_hmac_key_admin_roles ? local.names_set : toset([])
+  bucket   = google_storage_bucket.buckets[each.key].name
+  role     = "roles/storage.hmacKeyAdmin"
+  members = compact(
+    concat(
+      var.hmac_key_admins,
+      split(
+        ",",
+        lookup(var.bucket_hmac_key_admins, each.key, ""),
+      ),
+    ),
+  )
+}
+
+resource "google_storage_bucket_iam_binding" "storage_admins" {
+  for_each = var.set_storage_admin_roles ? local.names_set : toset([])
+  bucket   = google_storage_bucket.buckets[each.value].name
+  role     = "roles/storage.admin"
+  members = compact(
+    concat(
+      var.storage_admins,
+      split(
+        ",",
+        lookup(var.bucket_storage_admins, each.value, ""),
+      ),
+    ),
+  )
+}
+
 resource "google_storage_bucket_object" "folders" {
   for_each = { for obj in local.folder_list : "${obj.bucket}_${obj.folder}" => obj }
   bucket   = google_storage_bucket.buckets[each.value.bucket].name

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -27,6 +27,7 @@ module "project" {
   skip_gcloud_download = true
 
   activate_apis = [
+    "iam.googleapis.com",
     "storage-api.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -24,6 +24,8 @@ module "project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
+  skip_gcloud_download = true
+
   activate_apis = [
     "storage-api.googleapis.com",
     "cloudresourcemanager.googleapis.com",

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "labels" {
 
 variable "folders" {
   description = "Map of lowercase unprefixed name => list of top level folder objects."
-  type        = map(string)
+  type        = map(list(string))
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -43,25 +43,25 @@ variable "storage_class" {
 
 variable "force_destroy" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
-  type        = map
+  type        = map(bool)
   default     = {}
 }
 
 variable "versioning" {
   description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
-  type        = map
+  type        = map(bool)
   default     = {}
 }
 
 variable "encryption_key_names" {
   description = "Optional map of lowercase unprefixed name => string, empty strings are ignored."
-  type        = map
+  type        = map(string)
   default     = {}
 }
 
 variable "bucket_policy_only" {
   description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
-  type        = map
+  type        = map(bool)
   default     = {}
 }
 
@@ -96,20 +96,20 @@ variable "storage_admins" {
 }
 
 variable "bucket_admins" {
-  description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins."
-  type        = map
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket admins."
+  type        = map(string)
   default     = {}
 }
 
 variable "bucket_creators" {
-  description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket creators."
-  type        = map
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket creators."
+  type        = map(string)
   default     = {}
 }
 
 variable "bucket_viewers" {
-  description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers."
-  type        = map
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers."
+  type        = map(string)
   default     = {}
 }
 
@@ -127,13 +127,13 @@ variable "bucket_storage_admins" {
 
 variable "labels" {
   description = "Labels to be attached to the buckets"
-  type        = map
+  type        = map(string)
   default     = {}
 }
 
 variable "folders" {
   description = "Map of lowercase unprefixed name => list of top level folder objects."
-  type        = map
+  type        = map(string)
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,18 @@ variable "viewers" {
   default     = []
 }
 
+variable "hmac_key_admins" {
+  description = "IAM-style members who will be granted roles/storage.hmacKeyAdmin on all buckets."
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_admins" {
+  description = "IAM-style members who will be granted roles/storage.admin on all buckets."
+  type        = list(string)
+  default     = []
+}
+
 variable "bucket_admins" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket admins."
   type        = map
@@ -98,6 +110,18 @@ variable "bucket_creators" {
 variable "bucket_viewers" {
   description = "Map of lowercase unprefixed name => comma-delimited IAM-style bucket viewers."
   type        = map
+  default     = {}
+}
+
+variable "bucket_hmac_key_admins" {
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket HMAC Key admins."
+  type        = map(string)
+  default     = {}
+}
+
+variable "bucket_storage_admins" {
+  description = "Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket storage admins."
+  type        = map(string)
   default     = {}
 }
 
@@ -129,6 +153,18 @@ variable "set_creator_roles" {
 
 variable "set_viewer_roles" {
   description = "Grant roles/storage.objectViewer role to viewers and bucket_viewers."
+  type        = bool
+  default     = false
+}
+
+variable "set_hmac_key_admin_roles" {
+  description = "Grant roles/storage.hmacKeyAdmin role to hmac_key_admins and bucket_hmac_key_admins."
+  type        = bool
+  default     = false
+}
+
+variable "set_storage_admin_roles" {
+  description = "Grant roles/storage.admin role to storage_admins and bucket_storage_admins."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
fixes #18

this adds changes from #22 which were not included in #86

also:
- improve existing variable descriptions and types
- update dev tools to: 0.12.0
- test/setup/main.tf: add skip_gcloud_download = true
- test/setup/main.tf: add missing iam.googleapis.com to activate_apis