### PR TITLE
Support retention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Functional examples are included in the
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | `map(bool)` | `{}` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | `list(string)` | `[]` | no |
 | website | Map of website values. Supported attributes: main\_page\_suffix, not\_found\_page | `any` | `{}` | no |
+| retention_policy | Map of retention_policy values. Supported attributes: is\_locked, retention\_period | `any` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Functional examples are included in the
 | names | Bucket name suffixes. | `list(string)` | n/a | yes |
 | prefix | Prefix used to generate the bucket name. | `string` | n/a | yes |
 | project\_id | Bucket project id. | `string` | n/a | yes |
+| retention\_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket\_admins. | `bool` | `false` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket\_creators. | `bool` | `false` | no |
 | set\_hmac\_key\_admin\_roles | Grant roles/storage.hmacKeyAdmin role to hmac\_key\_admins and bucket\_hmac\_key\_admins. | `bool` | `false` | no |
@@ -76,7 +77,6 @@ Functional examples are included in the
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | `map(bool)` | `{}` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | `list(string)` | `[]` | no |
 | website | Map of website values. Supported attributes: main\_page\_suffix, not\_found\_page | `any` | `{}` | no |
-| retention\_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Functional examples are included in the
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | `map(bool)` | `{}` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | `list(string)` | `[]` | no |
 | website | Map of website values. Supported attributes: main\_page\_suffix, not\_found\_page | `any` | `{}` | no |
-| retention_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
+| retention\_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Functional examples are included in the
 | versioning | Optional map of lowercase unprefixed name => boolean, defaults to false. | `map(bool)` | `{}` | no |
 | viewers | IAM-style members who will be granted roles/storage.objectViewer on all buckets. | `list(string)` | `[]` | no |
 | website | Map of website values. Supported attributes: main\_page\_suffix, not\_found\_page | `any` | `{}` | no |
-| retention_policy | Map of retention_policy values. Supported attributes: is\_locked, retention\_period | `any` | `{}` | no |
+| retention_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
 
 ## Outputs
 

--- a/examples/multiple_buckets/README.md
+++ b/examples/multiple_buckets/README.md
@@ -8,7 +8,7 @@ This example illustrates how to use the `cloud-storage` module.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | bucket\_policy\_only | Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean | `map(string)` | `{}` | no |
-| folders | Top level bucket folders. Map of lowercase unprefixed name => list of folders to create. | `map` | `{}` | no |
+| folders | Top level bucket folders. Map of lowercase unprefixed name => list of folders to create. | `map(any)` | `{}` | no |
 | names | Names of the buckets to create. | `list(string)` | <pre>[<br>  "one",<br>  "two"<br>]</pre> | no |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 

--- a/examples/multiple_buckets/variables.tf
+++ b/examples/multiple_buckets/variables.tf
@@ -33,6 +33,6 @@ variable "bucket_policy_only" {
 
 variable "folders" {
   description = "Top level bucket folders. Map of lowercase unprefixed name => list of folders to create."
-  type        = map
+  type        = map(any)
   default     = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "google_storage_bucket" "buckets" {
   }
 
   dynamic "retention_policy" {
-    for_each = lookup(var.retention_policy, each.value, {}) != {} ? { v = lookup(var.retention_policy, each.value) } : {}
+    for_each = lookup(var.retention_policy, each.value, {}) != [] ? [var.retention_policy[each.value]]
     content {
       is_locked        = lookup(retention_policy.value, "is_locked", null)
       retention_period = lookup(retention_policy.value, "retention_period", null)

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "google_storage_bucket" "buckets" {
   }
 
   dynamic "retention_policy" {
-    for_each = lookup(var.retention_policy, each.value, {}) != [] ? [var.retention_policy[each.value]]
+    for_each = lookup(var.retention_policy, each.value, {}) != {} ? [var.retention_policy[each.value]] : []
     content {
       is_locked        = lookup(retention_policy.value, "is_locked", null)
       retention_period = lookup(retention_policy.value, "retention_period", null)

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,14 @@ resource "google_storage_bucket" "buckets" {
     }
   }
 
+  dynamic "retention_policy" {
+    for_each = lookup(var.retention_policy, each.value, {}) != {} ? { v = lookup(var.retention_policy, each.value) } : {}
+    content {
+      is_locked        = lookup(retention_policy.value, "is_locked", null)
+      retention_period = lookup(retention_policy.value, "retention_period", null)
+    }
+  }
+
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -201,6 +201,12 @@ variable "website" {
   description = "Map of website values. Supported attributes: main_page_suffix, not_found_page"
 }
 
+variable "retention_policy" {
+  type        = any
+  default     = {}
+  description = "Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy"
+}
+
 variable "logging" {
   description = "Map of lowercase unprefixed name => bucket logging config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#logging"
   type        = any


### PR DESCRIPTION
High. I have noticed that currently retention policy is supported only in `simple_bucket` module so I decided to jump in and add support for this feature also in the root module.