### PR TITLE
Add ability to append a randomized suffix to all bucket names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Functional examples are included in the
 | names | Bucket name suffixes. | `list(string)` | n/a | yes |
 | prefix | Prefix used to generate the bucket name. | `string` | n/a | yes |
 | project\_id | Bucket project id. | `string` | n/a | yes |
+| randomize\_suffix | Adds an identical, but randomized 4-character suffix to all bucket names | `bool` | `false` | no |
 | retention\_policy | Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy | `any` | `{}` | no |
 | set\_admin\_roles | Grant roles/storage.objectAdmin role to admins and bucket\_admins. | `bool` | `false` | no |
 | set\_creator\_roles | Grant roles/storage.objectCreator role to creators and bucket\_creators. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+/******************************************
+  Bucket random id suffix configuration
+ *****************************************/
+resource "random_id" "bucket_suffix" {
+  byte_length = 2
+}
+
 locals {
   prefix       = var.prefix == "" ? "" : join("-", [var.prefix, lower(var.location), ""])
+  suffix       = var.randomize_suffix ? "-${random_id.bucket_suffix.hex}" : ""
   names_set    = toset(var.names)
   buckets_list = [for name in var.names : google_storage_bucket.buckets[name]]
   first_bucket = local.buckets_list[0]
@@ -32,7 +40,7 @@ locals {
 resource "google_storage_bucket" "buckets" {
   for_each = local.names_set
 
-  name          = "${local.prefix}${lower(each.value)}"
+  name          = "${local.prefix}${lower(each.value)}${local.suffix}"
   project       = var.project_id
   location      = var.location
   storage_class = var.storage_class

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "names" {
   type        = list(string)
 }
 
+variable "randomize_suffix" {
+  description = "Adds an identical, but randomized 4-character suffix to all bucket names"
+  type        = bool
+  default     = false
+}
+
 variable "location" {
   description = "Bucket location."
   type        = string


### PR DESCRIPTION
Google Cloud Storage buckets need globally unique names. Therefore, it's helpful to have a randomized component to names, especially for use in example code. The following code 

```
resource "random_id" "bucket" {
  byte_length = 2
}

module "example_bucket" {
  source     = "terraform-google-modules/cloud-storage/google"
  version    = "~> 2.1"
  project_id = var.project_id
  location   = var.region

  prefix = "myproject"
  names  = ["data-${random_id.bucket.hex}"]
  versioning = {
    "data" : true
  }
  storage_class = "REGIONAL"
  admins = [
    module.sa_example.iam_email
  ]
  depends_on = [
    module.project_services
  ]
}
```

results in an error

```
│ The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this,
│ use the -target argument to first apply only the resources that the for_each depends on.
```

This is for well-understood reasons about `terraform plan` and iteration.  The `project-factory` module is subject to similar uniqueness requirements and resolves this issue by [creating a random resource inside the module][projfact]. This PR imitates that solution closely in order to aid the user (and developers of examples) to automatically create unique buckets that remain identifiable by eye.

[projfact]: https://github.com/terraform-google-modules/terraform-google-project-factory/blob/v11.1.1/modules/core_project_factory/main.tf#L20