### PR TITLE
Adds cft.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,12 @@ crash.log
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
 test/source.sh
-**/*.tfvars
 
 credentials.json
+
+# avoid versioning of credentials generated in codelab
+# https://codelabs.developers.google.com/cft-onboarding?hl=en#3
+cft.json
 
 # tf lock file
 .terraform.lock.hcl


### PR DESCRIPTION
The cft.json created in this codelab is being commited by mistake in some prs.
This can generate leak and bad usage.

Adding `cft.json` go `.gitignore` can avoid versioning files that should not be versioned.

https://codelabs.developers.google.com/cft-onboarding?hl=en#3