### PR TITLE
feat: add name and url outputs on simple_bucket module

### DIFF
--- a/modules/simple_bucket/README.md
+++ b/modules/simple_bucket/README.md
@@ -60,6 +60,8 @@ Functional examples are included in the
 | Name | Description |
 |------|-------------|
 | bucket | The created storage bucket |
+| name | Bucket name. |
+| url | Bucket URL. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/simple_bucket/outputs.tf
+++ b/modules/simple_bucket/outputs.tf
@@ -18,3 +18,13 @@ output "bucket" {
   description = "The created storage bucket"
   value       = google_storage_bucket.bucket
 }
+
+output "name" {
+  description = "Bucket name."
+  value       = google_storage_bucket.bucket.name
+}
+
+output "url" {
+  description = "Bucket URL."
+  value       = google_storage_bucket.bucket.url
+}


### PR DESCRIPTION
Hi,

It would be nice to have the same outputs as the "multi cloud storage" module:
* Name of the storage account (to ensure dependency composition with main module or other modules)
* URL of the bucket