### PR TITLE
Add option to enable default_event_based_hold argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Functional examples are included in the
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers. | `map(string)` | `{}` | no |
 | cors | Set of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | `set(any)` | `[]` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | `list(string)` | `[]` | no |
+| default\_event\_based\_hold | Enable event based hold to new objects added to specific bucket. Defaults to false. Map of lowercase unprefixed name => boolean | `map(bool)` | `{}` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | `map(string)` | `{}` | no |
 | folders | Map of lowercase unprefixed name => list of top level folder objects. | `map(list(string))` | `{}` | no |
 | force\_destroy | Optional map of lowercase unprefixed name => boolean, defaults to false. | `map(bool)` | `{}` | no |

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -44,4 +44,8 @@ module "cloud_storage" {
       matches_storage_class = "MULTI_REGIONAL,STANDARD,DURABLE_REDUCED_AVAILABILITY"
     }
   }]
+
+  default_event_based_hold = {
+    "two" = true
+  }
 }

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -46,6 +46,6 @@ module "cloud_storage" {
   }]
 
   default_event_based_hold = {
-    "two" = true
+    "one" = true
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,11 @@ resource "google_storage_bucket" "buckets" {
       false,
     )
   }
+  default_event_based_hold = lookup(
+    var.default_event_based_hold,
+    lower(each.value),
+    false,
+  )
   # Having a permanent encryption block with default_kms_key_name = "" works but results in terraform applying a change every run
   # There is no enabled = false attribute available to ask terraform to ignore the block
   dynamic "encryption" {

--- a/test/integration/multiple_buckets/multiple_buckets_test.go
+++ b/test/integration/multiple_buckets/multiple_buckets_test.go
@@ -51,9 +51,11 @@ func TestMultipleBuckets(t *testing.T) {
 			case "one":
 				// bucket with suffix one
 				assert.True(op.Get("metadata.iamConfiguration.bucketPolicyOnly.enabled").Bool(), "bucketPolicyOnly is enabled")
+				assert.True(op.Get("metadata.defaultEventBasedHold").Bool(), "defaultEventBasedHold is enabled")
 			case "two":
 				// bucket with suffix two
 				assert.False(op.Get("metadata.iamConfiguration.bucketPolicyOnly.enabled").Bool(), "bucketPolicyOnly is disabled")
+				assert.False(op.Get("metadata.defaultEventBasedHold").Bool(), "defaultEventBasedHold is disabled")
 				gcloud.Run(t, fmt.Sprintf("alpha storage ls --buckets gs://%s/dev/", bucketName), gcloudArgs)
 				gcloud.Run(t, fmt.Sprintf("alpha storage ls --buckets gs://%s/prod/", bucketName), gcloudArgs)
 			default:

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "bucket_policy_only" {
   default     = {}
 }
 
+variable "default_event_based_hold" {
+  description = "Enable event based hold to new objects added to specific bucket. Defaults to false. Map of lowercase unprefixed name => boolean"
+  type        = map(bool)
+  default     = {}
+}
+
 variable "admins" {
   description = "IAM-style members who will be granted roles/storage.objectAdmin on all buckets."
   type        = list(string)


### PR DESCRIPTION
Hi, in this PR I propose to have an option to set the argument `default_event_based_hold` with default value set to `false`. This will be useful for us who use this GCS Terraform module and have the requirement to enable object holds :smiley: 