### PR TITLE
chore: update gitignore for codelab creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,9 @@ test/source.sh
 
 credentials.json
 
+# avoid versioning of credentials generated in codelab
+# https://codelabs.developers.google.com/cft-onboarding?hl=en#3
+cft.json
+
 # tf lock file
 .terraform.lock.hcl


### PR DESCRIPTION
From https://github.com/terraform-google-modules/terraform-google-cloud-storage/pull/173 without the tfvars change