### PR TITLE
Sync matches_storage_class from multi_bucket module to simple_bucket module

### DIFF
--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -71,7 +71,7 @@ resource "google_storage_bucket" "bucket" {
         age                        = lookup(lifecycle_rule.value.condition, "age", null)
         created_before             = lookup(lifecycle_rule.value.condition, "created_before", null)
         with_state                 = lookup(lifecycle_rule.value.condition, "with_state", lookup(lifecycle_rule.value.condition, "is_live", false) ? "LIVE" : null)
-        matches_storage_class      = lookup(lifecycle_rule.value.condition, "matches_storage_class", null)
+        matches_storage_class      = contains(keys(lifecycle_rule.value.condition), "matches_storage_class") ? split(",", lifecycle_rule.value.condition["matches_storage_class"]) : null
         num_newer_versions         = lookup(lifecycle_rule.value.condition, "num_newer_versions", null)
         custom_time_before         = lookup(lifecycle_rule.value.condition, "custom_time_before", null)
         days_since_custom_time     = lookup(lifecycle_rule.value.condition, "days_since_custom_time", null)


### PR DESCRIPTION
Sync code from the main module to simple_bucket module, base issue https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/170 and https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/125