### PR TITLE
feat!: add support for custom_placement_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Functional examples are included in the
 | bucket\_viewers | Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers. | `map(string)` | `{}` | no |
 | cors | Set of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors | `set(any)` | `[]` | no |
 | creators | IAM-style members who will be granted roles/storage.objectCreators on all buckets. | `list(string)` | `[]` | no |
+| custom\_placement\_config | Map of lowercase unprefixed name => custom placement config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#custom_placement_config | `any` | `{}` | no |
 | default\_event\_based\_hold | Enable event based hold to new objects added to specific bucket. Defaults to false. Map of lowercase unprefixed name => boolean | `map(bool)` | `{}` | no |
 | encryption\_key\_names | Optional map of lowercase unprefixed name => string, empty strings are ignored. | `map(string)` | `{}` | no |
 | folders | Map of lowercase unprefixed name => list of top level folder objects. | `map(list(string))` | `{}` | no |

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -31,12 +31,6 @@ module "cloud_storage" {
     "two" = false
   }
 
-  custom_placement_config = {
-    "one" = {
-      data_locations : ["europe-north1", "europe-west1"]
-    }
-  }
-
   folders = {
     "two" = ["dev", "prod"]
   }

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -30,6 +30,13 @@ module "cloud_storage" {
     "one" = true
     "two" = false
   }
+
+  custom_placement_config = {
+    "one" = {
+      data_locations : ["europe-north1", "europe-west1"]
+    }
+  }
+
   folders = {
     "two" = ["dev", "prod"]
   }

--- a/examples/simple_bucket/main.tf
+++ b/examples/simple_bucket/main.tf
@@ -19,7 +19,7 @@ module "bucket" {
 
   name       = "${var.project_id}-bucket"
   project_id = var.project_id
-  location   = "us-east1"
+  location   = "us"
 
   lifecycle_rules = [{
     action = {
@@ -31,6 +31,10 @@ module "bucket" {
       matches_prefix = var.project_id
     }
   }]
+
+  custom_placement_config = {
+    data_locations : ["US-EAST4", "US-WEST1"]
+  }
 
   iam_members = [{
     role   = "roles/storage.objectViewer"

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,13 @@ resource "google_storage_bucket" "buckets" {
     }
   }
 
+  dynamic "custom_placement_config" {
+    for_each = lookup(var.custom_placement_config, each.value, {}) != {} ? [var.custom_placement_config[each.value]] : []
+    content {
+      data_locations = lookup(custom_placement_config.value, "data_locations", null)
+    }
+  }
+
   dynamic "lifecycle_rule" {
     for_each = setunion(var.lifecycle_rules, lookup(var.bucket_lifecycle_rules, each.value, toset([])))
     content {

--- a/modules/simple_bucket/README.md
+++ b/modules/simple_bucket/README.md
@@ -40,6 +40,7 @@ Functional examples are included in the
 |------|-------------|------|---------|:--------:|
 | bucket\_policy\_only | Enables Bucket Policy Only access to a bucket. | `bool` | `true` | no |
 | cors | Configuration of CORS for bucket with structure as defined in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#cors. | `any` | `[]` | no |
+| custom\_placement\_config | Configuration of the bucket's custom location in a dual-region bucket setup. If the bucket is designated a single or multi-region, the variable are null. | <pre>object({<br>    data_locations = list(string)<br>  })</pre> | `null` | no |
 | encryption | A Cloud KMS key that will be used to encrypt objects inserted into this bucket | <pre>object({<br>    default_kms_key_name = string<br>  })</pre> | `null` | no |
 | force\_destroy | When deleting a bucket, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects. | `bool` | `false` | no |
 | iam\_members | The list of IAM members to grant permissions on the bucket. | <pre>list(object({<br>    role   = string<br>    member = string<br>  }))</pre> | `[]` | no |

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -61,6 +61,13 @@ resource "google_storage_bucket" "bucket" {
     }
   }
 
+  dynamic "custom_placement_config" {
+    for_each = var.custom_placement_config == null ? [] : [var.custom_placement_config]
+    content {
+      data_locations = var.custom_placement_config.data_locations
+    }
+  }
+
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules
     content {

--- a/modules/simple_bucket/variables.tf
+++ b/modules/simple_bucket/variables.tf
@@ -78,6 +78,14 @@ variable "retention_policy" {
   default = null
 }
 
+variable "custom_placement_config" {
+  description = "Configuration of the bucket's custom location in a dual-region bucket setup. If the bucket is designated a single or multi-region, the variable are null."
+  type = object({
+    data_locations = list(string)
+  })
+  default = null
+}
+
 variable "cors" {
   description = "Configuration of CORS for bucket with structure as defined in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#cors."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -248,6 +248,12 @@ variable "retention_policy" {
   description = "Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy"
 }
 
+variable "custom_placement_config" {
+  type        = any
+  default     = {}
+  description = "Map of lowercase unprefixed name => custom placement config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#custom_placement_config"
+}
+
 variable "logging" {
   description = "Map of lowercase unprefixed name => bucket logging config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#logging"
   type        = any


### PR DESCRIPTION
Add support for custom_placement_config which was added to provider in version [4.40.0](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#4400-october-10-2022).

`custom_placement_config` is used for dual-region bucket configuration.

Docs for custom_placement_config: https://registry.terraform.io/providers/hashicorp/google/4.56.0/docs/resources/storage_bucket#custom_placement_config

