### PR TITLE
chore: remove version constraint "< 5.0" for "hashicorp/google"

### DIFF
--- a/modules/simple_bucket/versions.tf
+++ b/modules/simple_bucket/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.46, < 5.0"
+      version = ">= 4.46"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.46, < 5.0"
+      version = ">= 4.46"
     }
 
     random = {


### PR DESCRIPTION
With 5.0 of "hashicorp/google" released, the constraint should be removed.