### PR TITLE
chore: upgraded versions.tf to include minor bumps from tag v5.1.0

### DIFF
--- a/modules/simple_bucket/versions.tf
+++ b/modules/simple_bucket/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.46, < 5.0"
+      version = ">= 4.46, < 6.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.46, < 5.0"
+      version = ">= 4.46, < 6.0"
     }
 
     random = {


### PR DESCRIPTION
The version must be set to < 6.0. Using < 5.0.0 as the constraint would lead to compatibility issues with version 5.1.0.