### PR TITLE
feat: add labels variable validations

### DIFF
--- a/test/integration/multiple_buckets/multiple_buckets_test.go
+++ b/test/integration/multiple_buckets/multiple_buckets_test.go
@@ -55,7 +55,7 @@ func TestMultipleBuckets(t *testing.T) {
 
 			// peel bucket name from prefix and randomized suffix
 			parts := strings.Split(fullBucketName, "-")
-			bucketName := parts[len(parts) - 2]
+			bucketName := parts[len(parts)-2]
 
 			switch bucketName {
 			case "one":
@@ -79,5 +79,49 @@ func TestMultipleBuckets(t *testing.T) {
 			}
 		}
 	})
+	buckets.Test()
+}
+
+func TestValidLabels(t *testing.T) {
+	buckets := tft.NewTFBlueprintTest(t, tft.WithRetryableTerraformErrors(retryErrors, 5, time.Minute))
+
+	buckets.DefineVerify(func(assert *assert.Assertions) {
+		buckets.DefaultVerify(assert)
+
+		labels := map[string]interface{}{
+			"valid_label_1": "value_1",
+			"valid_label_2": "value_2",
+		}
+
+		options := buckets.GetTFOptions()
+		options.Vars = map[string]interface{}{
+			"labels": labels,
+		}
+
+		terraform.InitAndApply(t, options)
+	})
+
+	buckets.Test()
+}
+
+func TestInvalidLabels(t *testing.T) {
+	buckets := tft.NewTFBlueprintTest(t, tft.WithRetryableTerraformErrors(retryErrors, 5, time.Minute))
+
+	buckets.DefineVerify(func(assert *assert.Assertions) {
+		buckets.DefaultVerify(assert)
+
+		invalidLabels := map[string]interface{}{
+			"invalid_label_123456789012345678901234567890123456789012345678901234567890": "Value_1",
+		}
+
+		options := buckets.GetTFOptions()
+		options.Vars = map[string]interface{}{
+			"labels": invalidLabels,
+		}
+
+		_, err := terraform.InitAndApplyE(t, options)
+		assert.Error(err)
+	})
+
 	buckets.Test()
 }

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,22 @@ variable "labels" {
   description = "Labels to be attached to the buckets"
   type        = map(string)
   default     = {}
+  # Validations based on https://cloud.google.com/storage/docs/tags-and-labels#bucket-labels
+  validation {
+    condition = alltrue([
+      for key, value in var.labels : (
+        can(regex("^[a-z0-9_-]{1,63}$", key)) &&
+        can(regex("^[a-z0-9_-]{1,63}$", value)) &&
+        length(key) <= 63 &&
+        length(value) <= 63
+      )
+    ])
+    error_message = "Keys and values must meet the specified criteria: lowercase letters, numbers, underscores, and dashes, and be up to 63 characters long."
+  }
+  validation {
+    condition     = length(keys(var.labels)) <= 64
+    error_message = "The map should contain up to 64 objects"
+  }
 }
 
 variable "folders" {


### PR DESCRIPTION
Hey 👋 
A quick PR to add some labels validations based on the [documentation](https://cloud.google.com/storage/docs/tags-and-labels#bucket-labels).
The problem this PR is trying to solve, is that nothing validates that the labels are correct before the `apply` phase which gets and error from the API.
Tests added as well.

Thanks 