### PR TITLE
fix: use null as default for lookup

### DIFF
--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -65,6 +65,13 @@ module "cloud_storage" {
     ]
   }
 
+  retention_policy = {
+    "two" = {
+      is_locked        = false
+      retention_period = 3600
+    }
+  }
+
   default_event_based_hold = {
     "one" = true
   }

--- a/examples/multiple_buckets/main.tf
+++ b/examples/multiple_buckets/main.tf
@@ -68,7 +68,7 @@ module "cloud_storage" {
   retention_policy = {
     "two" = {
       is_locked        = false
-      retention_period = 3600
+      retention_period = 1
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "google_storage_bucket" "buckets" {
   }
 
   dynamic "retention_policy" {
-    for_each = lookup(var.retention_policy, each.value, {}) != {} ? [var.retention_policy[each.value]] : []
+    for_each = lookup(var.retention_policy, each.value, null) != null ? [var.retention_policy[each.value]] : []
     content {
       is_locked        = lookup(retention_policy.value, "is_locked", null)
       retention_period = lookup(retention_policy.value, "retention_period", null)
@@ -119,7 +119,7 @@ resource "google_storage_bucket" "buckets" {
   }
 
   dynamic "custom_placement_config" {
-    for_each = lookup(var.custom_placement_config, each.value, {}) != {} ? [var.custom_placement_config[each.value]] : []
+    for_each = lookup(var.custom_placement_config, each.value, null) != null ? [var.custom_placement_config[each.value]] : []
     content {
       data_locations = lookup(custom_placement_config.value, "data_locations", null)
     }
@@ -149,7 +149,7 @@ resource "google_storage_bucket" "buckets" {
   }
 
   dynamic "logging" {
-    for_each = lookup(var.logging, each.value, {}) != {} ? { v = lookup(var.logging, each.value) } : {}
+    for_each = lookup(var.logging, each.value, null) != null ? { v = lookup(var.logging, each.value) } : {}
     content {
       log_bucket        = lookup(logging.value, "log_bucket", null)
       log_object_prefix = lookup(logging.value, "log_object_prefix", null)

--- a/test/integration/multiple_buckets/multiple_buckets_test.go
+++ b/test/integration/multiple_buckets/multiple_buckets_test.go
@@ -73,7 +73,7 @@ func TestMultipleBuckets(t *testing.T) {
 				gcloud.Run(t, fmt.Sprintf("alpha storage ls --buckets gs://%s/prod/", fullBucketName), gcloudArgs)
 				bucket_lifecycles := op.Get("metadata.lifecycle.rule").Array()
 				assert.Equal(1, len(bucket_lifecycles), "Bucket 'two' has 1 lifecycle rule")
-				assert.Equal("3600", op.Get("metadata.retentionPolicy.retentionPeriod").String(), "bucket retention policy retention period is 3600")
+				assert.Equal("1", op.Get("metadata.retentionPolicy.retentionPeriod").String(), "bucket retention policy retention period is 1")
 			default:
 				// fail test if unknown suffix
 				t.Fatalf("Only expected two buckets with suffixes one and two. Found: %s", fullBucketName)

--- a/test/integration/multiple_buckets/multiple_buckets_test.go
+++ b/test/integration/multiple_buckets/multiple_buckets_test.go
@@ -73,6 +73,7 @@ func TestMultipleBuckets(t *testing.T) {
 				gcloud.Run(t, fmt.Sprintf("alpha storage ls --buckets gs://%s/prod/", fullBucketName), gcloudArgs)
 				bucket_lifecycles := op.Get("metadata.lifecycle.rule").Array()
 				assert.Equal(1, len(bucket_lifecycles), "Bucket 'two' has 1 lifecycle rule")
+				assert.Equal("3600", op.Get("metadata.retentionPolicy.retentionPeriod").String(), "bucket retention policy retention period is 3600")
 			default:
 				// fail test if unknown suffix
 				t.Fatalf("Only expected two buckets with suffixes one and two. Found: %s", fullBucketName)


### PR DESCRIPTION
Currently, any `retention_policy` throws this error:

```
╷
│ Error: Invalid function argument
│
│   on .terraform\modules\my_buckets.gcs_bucket\main.tf line 114, in resource "google_storage_bucket" "buckets":
│  114:     for_each = lookup(var.retention_policy, each.value, {}) != {} ? [var.retention_policy[each.value]] : []
│     ├────────────────
│     │ while calling lookup(inputMap, key, default...)
│
│ Invalid value for "default" parameter: the default value must have the same type as the map elements.
╵
```

This fixes the default for the lookup, similar to https://github.com/terraform-google-modules/terraform-google-cloud-storage/pull/318. Given that this seems to be a recurring bug, it might be worth looking into 

https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/07e3a4e2b34dc4c7a2a99ae5e6893a3670251870/main.tf#L122

https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/07e3a4e2b34dc4c7a2a99ae5e6893a3670251870/main.tf#L152

