### PR TITLE
chore: Add connection metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22.8
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22.8
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -65,6 +65,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
+	    -e ENABLE_BPMETADATA \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh
@@ -82,6 +83,7 @@ docker_test_lint_gha:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+	    -e ENABLE_BPMETADATA \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,258 +19,257 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
-  title: Terraform Google Cloud Storage Module
-  source:
-    repo: https://github.com/terraform-google-modules/terraform-google-cloud-storage.git
-    sourceType: git
-  version: 6.1.0
-  actuationTool:
-    type: Terraform
-    version: '>= 0.13'
-  subBlueprints:
-  - name: simple_bucket
-    location: modules/simple_bucket
-  examples:
-  - name: multiple_buckets
-    location: examples/multiple_buckets
-  - name: simple_bucket
-    location: examples/simple_bucket
-  variables:
-  - name: admins
-    description: IAM-style members who will be granted roles/storage.objectAdmin on all buckets.
-    type: list(string)
-    default: []
-    required: false
-  - name: bucket_admins
-    description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket admins.
-    type: map(string)
-    default: {}
-    required: false
-  - name: bucket_creators
-    description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket creators.
-    type: map(string)
-    default: {}
-    required: false
-  - name: bucket_hmac_key_admins
-    description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket HMAC Key admins.
-    type: map(string)
-    default: {}
-    required: false
-  - name: bucket_lifecycle_rules
-    description: Additional lifecycle_rules for specific buckets. Map of lowercase unprefixed name => list of lifecycle rules to configure.
-    type: |-
-      map(set(object({
-          # Object with keys:
-          # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
-          # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
-          action = map(string)
+  info:
+    title: Terraform Google Cloud Storage Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-cloud-storage.git
+      sourceType: git
+    version: 6.0.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: simple_bucket
+        location: modules/simple_bucket
+    examples:
+      - name: multiple_buckets
+        location: examples/multiple_buckets
+      - name: simple_bucket
+        location: examples/simple_bucket
+  interfaces:
+    variables:
+      - name: admins
+        description: IAM-style members who will be granted roles/storage.objectAdmin on all buckets.
+        varType: list(string)
+        defaultValue: []
+      - name: autoclass
+        description: Optional map of lowercase unprefixed bucket name => boolean, defaults to false.
+        varType: map(bool)
+        defaultValue: {}
+      - name: bucket_admins
+        description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket admins.
+        varType: map(string)
+        defaultValue: {}
+      - name: bucket_creators
+        description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket creators.
+        varType: map(string)
+        defaultValue: {}
+      - name: bucket_hmac_key_admins
+        description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket HMAC Key admins.
+        varType: map(string)
+        defaultValue: {}
+      - name: bucket_lifecycle_rules
+        description: Additional lifecycle_rules for specific buckets. Map of lowercase unprefixed name => list of lifecycle rules to configure.
+        varType: |-
+          map(set(object({
+              # Object with keys:
+              # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
+              # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
+              action = map(string)
 
-          # Object with keys:
-          # - age - (Optional) Minimum age of an object in days to satisfy this condition.
-          # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
-          # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
-          # - matches_storage_class - (Optional) Comma delimited string for storage class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
-          # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
-          # - custom_time_before - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
-          # - days_since_custom_time - (Optional) The number of days from the Custom-Time metadata attribute after which this condition becomes true.
-          # - days_since_noncurrent_time - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.
-          # - noncurrent_time_before - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.
-          condition = map(string)
-        })))
-    default: {}
-    required: false
-  - name: bucket_policy_only
-    description: Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean
-    type: map(bool)
-    default: {}
-    required: false
-  - name: bucket_storage_admins
-    description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket storage admins.
-    type: map(string)
-    default: {}
-    required: false
-  - name: bucket_viewers
-    description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers.
-    type: map(string)
-    default: {}
-    required: false
-  - name: cors
-    description: 'Set of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors'
-    type: set(any)
-    default: []
-    required: false
-  - name: creators
-    description: IAM-style members who will be granted roles/storage.objectCreators on all buckets.
-    type: list(string)
-    default: []
-    required: false
-  - name: default_event_based_hold
-    description: Enable event based hold to new objects added to specific bucket. Defaults to false. Map of lowercase unprefixed name => boolean
-    type: map(bool)
-    default: {}
-    required: false
-  - name: encryption_key_names
-    description: Optional map of lowercase unprefixed name => string, empty strings are ignored.
-    type: map(string)
-    default: {}
-    required: false
-  - name: folders
-    description: Map of lowercase unprefixed name => list of top level folder objects.
-    type: map(list(string))
-    default: {}
-    required: false
-  - name: force_destroy
-    description: Optional map of lowercase unprefixed name => boolean, defaults to false.
-    type: map(bool)
-    default: {}
-    required: false
-  - name: hmac_key_admins
-    description: IAM-style members who will be granted roles/storage.hmacKeyAdmin on all buckets.
-    type: list(string)
-    default: []
-    required: false
-  - name: labels
-    description: Labels to be attached to the buckets
-    type: map(string)
-    default: {}
-    required: false
-  - name: lifecycle_rules
-    description: List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string.
-    type: |-
-      set(object({
-          # Object with keys:
-          # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
-          # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
-          action = map(string)
+              # Object with keys:
+              # - age - (Optional) Minimum age of an object in days to satisfy this condition.
+              # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
+              # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
+              # - matches_storage_class - (Optional) Comma delimited string for storage class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
+              # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
+              # - custom_time_before - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
+              # - days_since_custom_time - (Optional) The number of days from the Custom-Time metadata attribute after which this condition becomes true.
+              # - days_since_noncurrent_time - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.
+              # - noncurrent_time_before - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.
+              condition = map(string)
+            })))
+        defaultValue: {}
+      - name: bucket_policy_only
+        description: Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean
+        varType: map(bool)
+        defaultValue: {}
+      - name: bucket_storage_admins
+        description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket storage admins.
+        varType: map(string)
+        defaultValue: {}
+      - name: bucket_viewers
+        description: Map of lowercase unprefixed name => comma-delimited IAM-style per-bucket viewers.
+        varType: map(string)
+        defaultValue: {}
+      - name: cors
+        description: "Set of maps of mixed type attributes for CORS values. See appropriate attribute types here: https://www.terraform.io/docs/providers/google/r/storage_bucket.html#cors"
+        varType: set(any)
+        defaultValue: []
+      - name: creators
+        description: IAM-style members who will be granted roles/storage.objectCreators on all buckets.
+        varType: list(string)
+        defaultValue: []
+      - name: custom_placement_config
+        description: Map of lowercase unprefixed name => custom placement config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#custom_placement_config
+        varType: any
+        defaultValue: {}
+      - name: default_event_based_hold
+        description: Enable event based hold to new objects added to specific bucket. Defaults to false. Map of lowercase unprefixed name => boolean
+        varType: map(bool)
+        defaultValue: {}
+      - name: encryption_key_names
+        description: Optional map of lowercase unprefixed name => string, empty strings are ignored.
+        varType: map(string)
+        defaultValue: {}
+      - name: folders
+        description: Map of lowercase unprefixed name => list of top level folder objects.
+        varType: map(list(string))
+        defaultValue: {}
+      - name: force_destroy
+        description: Optional map of lowercase unprefixed name => boolean, defaults to false.
+        varType: map(bool)
+        defaultValue: {}
+      - name: hmac_key_admins
+        description: IAM-style members who will be granted roles/storage.hmacKeyAdmin on all buckets.
+        varType: list(string)
+        defaultValue: []
+      - name: hmac_service_accounts
+        description: List of HMAC service accounts to grant access to GCS.
+        varType: map(string)
+        defaultValue: {}
+      - name: labels
+        description: Labels to be attached to the buckets
+        varType: map(string)
+        defaultValue: {}
+      - name: lifecycle_rules
+        description: List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string.
+        varType: |-
+          set(object({
+              # Object with keys:
+              # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
+              # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
+              action = map(string)
 
-          # Object with keys:
-          # - age - (Optional) Minimum age of an object in days to satisfy this condition.
-          # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
-          # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
-          # - matches_storage_class - (Optional) Comma delimited string for storage class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
-          # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
-          # - custom_time_before - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
-          # - days_since_custom_time - (Optional) The number of days from the Custom-Time metadata attribute after which this condition becomes true.
-          # - days_since_noncurrent_time - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.
-          # - noncurrent_time_before - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.
-          condition = map(string)
-        }))
-    default: []
-    required: false
-  - name: location
-    description: Bucket location.
-    type: string
-    default: EU
-    required: false
-  - name: logging
-    description: Map of lowercase unprefixed name => bucket logging config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#logging
-    type: any
-    default: {}
-    required: false
-  - name: names
-    description: Bucket name suffixes.
-    type: list(string)
-    required: true
-  - name: prefix
-    description: Prefix used to generate the bucket name.
-    type: string
-    required: true
-  - name: project_id
-    description: Bucket project id.
-    type: string
-    required: true
-  - name: randomize_suffix
-    description: Adds an identical, but randomized 4-character suffix to all bucket names
-    type: bool
-    default: false
-    required: false
-  - name: retention_policy
-    description: Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy
-    type: any
-    default: {}
-    required: false
-  - name: set_admin_roles
-    description: Grant roles/storage.objectAdmin role to admins and bucket_admins.
-    type: bool
-    default: false
-    required: false
-  - name: set_creator_roles
-    description: Grant roles/storage.objectCreator role to creators and bucket_creators.
-    type: bool
-    default: false
-    required: false
-  - name: set_hmac_key_admin_roles
-    description: Grant roles/storage.hmacKeyAdmin role to hmac_key_admins and bucket_hmac_key_admins.
-    type: bool
-    default: false
-    required: false
-  - name: set_storage_admin_roles
-    description: Grant roles/storage.admin role to storage_admins and bucket_storage_admins.
-    type: bool
-    default: false
-    required: false
-  - name: set_viewer_roles
-    description: Grant roles/storage.objectViewer role to viewers and bucket_viewers.
-    type: bool
-    default: false
-    required: false
-  - name: storage_admins
-    description: IAM-style members who will be granted roles/storage.admin on all buckets.
-    type: list(string)
-    default: []
-    required: false
-  - name: storage_class
-    description: Bucket storage class.
-    type: string
-    default: STANDARD
-    required: false
-  - name: versioning
-    description: Optional map of lowercase unprefixed name => boolean, defaults to false.
-    type: map(bool)
-    default: {}
-    required: false
-  - name: viewers
-    description: IAM-style members who will be granted roles/storage.objectViewer on all buckets.
-    type: list(string)
-    default: []
-    required: false
-  - name: website
-    description: 'Map of website values. Supported attributes: main_page_suffix, not_found_page'
-    type: map(any)
-    default: {}
-    required: false
-  - name: autoclass
-    description: Optional map of lowercase unprefixed bucket name => boolean, defaults to false.
-    type: map(bool)
-    default: {}
-    required: false
-  outputs:
-  - name: bucket
-    description: Bucket resource (for single use).
-  - name: buckets
-    description: Bucket resources as list.
-  - name: buckets_map
-    description: Bucket resources by name.
-  - name: name
-    description: Bucket name (for single use).
-  - name: names
-    description: Bucket names.
-  - name: names_list
-    description: List of bucket names.
-  - name: url
-    description: Bucket URL (for single use).
-  - name: urls
-    description: Bucket URLs.
-  - name: urls_list
-    description: List of bucket URLs.
-  roles:
-  - level: Project
+              # Object with keys:
+              # - age - (Optional) Minimum age of an object in days to satisfy this condition.
+              # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
+              # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
+              # - matches_storage_class - (Optional) Comma delimited string for storage class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
+              # - matches_prefix - (Optional) One or more matching name prefixes to satisfy this condition.
+              # - matches_suffix - (Optional) One or more matching name suffixes to satisfy this condition.
+              # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
+              # - custom_time_before - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
+              # - days_since_custom_time - (Optional) The number of days from the Custom-Time metadata attribute after which this condition becomes true.
+              # - days_since_noncurrent_time - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.
+              # - noncurrent_time_before - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.
+              condition = map(string)
+            }))
+        defaultValue: []
+      - name: location
+        description: Bucket location.
+        varType: string
+        defaultValue: EU
+      - name: logging
+        description: Map of lowercase unprefixed name => bucket logging config object. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#logging
+        varType: any
+        defaultValue: {}
+      - name: names
+        description: Bucket name suffixes.
+        varType: list(string)
+        required: true
+      - name: prefix
+        description: Prefix used to generate the bucket name.
+        varType: string
+        defaultValue: ""
+      - name: project_id
+        description: Bucket project id.
+        varType: string
+        required: true
+      - name: public_access_prevention
+        description: Prevents public access to a bucket. Acceptable values are inherited or enforced. If inherited, the bucket uses public access prevention, only if the bucket is subject to the public access prevention organization policy constraint.
+        varType: string
+        defaultValue: inherited
+      - name: randomize_suffix
+        description: Adds an identical, but randomized 4-character suffix to all bucket names
+        varType: bool
+        defaultValue: false
+      - name: retention_policy
+        description: Map of retention policy values. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket#retention_policy
+        varType: any
+        defaultValue: {}
+      - name: set_admin_roles
+        description: Grant roles/storage.objectAdmin role to admins and bucket_admins.
+        varType: bool
+        defaultValue: false
+      - name: set_creator_roles
+        description: Grant roles/storage.objectCreator role to creators and bucket_creators.
+        varType: bool
+        defaultValue: false
+      - name: set_hmac_access
+        description: Set S3 compatible access to GCS.
+        varType: bool
+        defaultValue: false
+      - name: set_hmac_key_admin_roles
+        description: Grant roles/storage.hmacKeyAdmin role to hmac_key_admins and bucket_hmac_key_admins.
+        varType: bool
+        defaultValue: false
+      - name: set_storage_admin_roles
+        description: Grant roles/storage.admin role to storage_admins and bucket_storage_admins.
+        varType: bool
+        defaultValue: false
+      - name: set_viewer_roles
+        description: Grant roles/storage.objectViewer role to viewers and bucket_viewers.
+        varType: bool
+        defaultValue: false
+      - name: soft_delete_policy
+        description: Soft delete policies to apply. Map of lowercase unprefixed name => soft delete policy. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#nested_soft_delete_policy
+        varType: map(any)
+        defaultValue: {}
+      - name: storage_admins
+        description: IAM-style members who will be granted roles/storage.admin on all buckets.
+        varType: list(string)
+        defaultValue: []
+      - name: storage_class
+        description: Bucket storage class.
+        varType: string
+        defaultValue: STANDARD
+      - name: versioning
+        description: Optional map of lowercase unprefixed name => boolean, defaults to false.
+        varType: map(bool)
+        defaultValue: {}
+      - name: viewers
+        description: IAM-style members who will be granted roles/storage.objectViewer on all buckets.
+        varType: list(string)
+        defaultValue: []
+      - name: website
+        description: "Map of website values. Supported attributes: main_page_suffix, not_found_page"
+        varType: map(any)
+        defaultValue: {}
+    outputs:
+      - name: bucket
+        description: Bucket resource (for single use).
+      - name: buckets
+        description: Bucket resources as list.
+      - name: buckets_map
+        description: Bucket resources by name.
+      - name: hmac_keys
+        description: List of HMAC keys.
+      - name: name
+        description: Bucket name (for single use).
+      - name: names
+        description: Bucket names.
+      - name: names_list
+        description: List of bucket names.
+      - name: url
+        description: Bucket URL (for single use).
+      - name: urls
+        description: Bucket URLs.
+      - name: urls_list
+        description: List of bucket URLs.
+  requirements:
     roles:
-    - roles/storage.admin
-    - roles/iam.serviceAccountUser
-  services:
-  - iam.googleapis.com
-  - storage-api.googleapis.com
-  - cloudresourcemanager.googleapis.com
-  - compute.googleapis.com
-  - serviceusage.googleapis.com
+      - level: Project
+        roles:
+          - roles/cloudkms.admin
+          - roles/iam.serviceAccountUser
+          - roles/storage.admin
+    services:
+      - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - compute.googleapis.com
+      - iam.googleapis.com
+      - serviceusage.googleapis.com
+      - storage-api.googleapis.com

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -114,7 +114,7 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_bucket_iam_member" "members" {
   for_each = {
-    for m in var.iam_members : "${m.role} ${m.member}" => m
+    for index, m in var.iam_members : "${index} ${m.role}" => m
   }
   bucket = google_storage_bucket.bucket.name
   role   = each.value.role

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -114,7 +114,7 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_bucket_iam_member" "members" {
   for_each = {
-    for index, m in var.iam_members : "${index} ${m.role}" => m
+    for m in var.iam_members : "${m.role} ${m.member}" => m
   }
   bucket = google_storage_bucket.bucket.name
   role   = each.value.role

--- a/modules/simple_bucket/metadata.yaml
+++ b/modules/simple_bucket/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,136 +19,156 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
-  title: Terraform Google Cloud Storage Module
-  source:
-    repo: https://github.com/terraform-google-modules/terraform-google-cloud-storage.git
-    sourceType: git
-  version: 6.1.0
-  actuationTool:
-    type: Terraform
-    version: '>= 0.13'
-  examples:
-  - name: multiple_buckets
-    location: examples/multiple_buckets
-  - name: simple_bucket
-    location: examples/simple_bucket
-  variables:
-  - name: bucket_policy_only
-    description: Enables Bucket Policy Only access to a bucket.
-    type: bool
-    default: true
-    required: false
-  - name: cors
-    description: Configuration of CORS for bucket with structure as defined in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#cors.
-    type: any
-    default: []
-    required: false
-  - name: encryption
-    description: A Cloud KMS key that will be used to encrypt objects inserted into this bucket
-    type: |-
-      object({
-          default_kms_key_name = string
-        })
-    required: false
-  - name: force_destroy
-    description: When deleting a bucket, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects.
-    type: bool
-    default: false
-    required: false
-  - name: iam_members
-    description: The list of IAM members to grant permissions on the bucket.
-    type: |-
-      list(object({
-          role   = string
-          member = string
-        }))
-    default: []
-    required: false
-  - name: labels
-    description: A set of key/value label pairs to assign to the bucket.
-    type: map(string)
-    required: false
-  - name: lifecycle_rules
-    description: The bucket's Lifecycle Rules configuration.
-    type: |-
-      list(object({
-          # Object with keys:
-          # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
-          # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
-          action = any
+  info:
+    title: Terraform Google Cloud Storage Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-cloud-storage.git
+      sourceType: git
+      dir: /modules/simple_bucket
+    version: 6.0.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    examples:
+      - name: multiple_buckets
+        location: examples/multiple_buckets
+      - name: simple_bucket
+        location: examples/simple_bucket
+  interfaces:
+    variables:
+      - name: autoclass
+        description: While set to true, autoclass is enabled for this bucket.
+        varType: bool
+        defaultValue: false
+      - name: bucket_policy_only
+        description: Enables Bucket Policy Only access to a bucket.
+        varType: bool
+        defaultValue: true
+      - name: cors
+        description: Configuration of CORS for bucket with structure as defined in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#cors.
+        varType: any
+        defaultValue: []
+      - name: custom_placement_config
+        description: Configuration of the bucket's custom location in a dual-region bucket setup. If the bucket is designated a single or multi-region, the variable are null.
+        varType: |-
+          object({
+              data_locations = list(string)
+            })
+      - name: encryption
+        description: A Cloud KMS key that will be used to encrypt objects inserted into this bucket. If default_kms_key_name is set to 'null' a new keyring and key pair will be created and used to encrypt bucket using CMEK.
+        varType: |-
+          object({
+              default_kms_key_name = string
+            })
+      - name: force_destroy
+        description: When deleting a bucket, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects.
+        varType: bool
+        defaultValue: false
+      - name: iam_members
+        description: The list of IAM members to grant permissions on the bucket.
+        varType: |-
+          list(object({
+              role   = string
+              member = string
+            }))
+        defaultValue: []
+        connections:
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
+              version: v0.12.0
+            spec:
+              outputExpr: service_account_id.member
+              inputPath: member
+      - name: labels
+        description: A set of key/value label pairs to assign to the bucket.
+        varType: map(string)
+      - name: lifecycle_rules
+        description: The bucket's Lifecycle Rules configuration.
+        varType: |-
+          list(object({
+              # Object with keys:
+              # - type - The type of the action of this Lifecycle Rule. Supported values: Delete and SetStorageClass.
+              # - storage_class - (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule.
+              action = any
 
-          # Object with keys:
-          # - age - (Optional) Minimum age of an object in days to satisfy this condition.
-          # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
-          # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
-          # - matches_storage_class - (Optional) Storage Class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
-          # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
-          condition = any
-        }))
-    default: []
-    required: false
-  - name: location
-    description: The location of the bucket.
-    type: string
-    required: true
-  - name: log_bucket
-    description: The bucket that will receive log objects.
-    type: string
-    required: false
-  - name: log_object_prefix
-    description: The object prefix for log objects. If it's not provided, by default GCS sets this to this bucket's name
-    type: string
-    required: false
-  - name: name
-    description: The name of the bucket.
-    type: string
-    required: true
-  - name: project_id
-    description: The ID of the project to create the bucket in.
-    type: string
-    required: true
-  - name: retention_policy
-    description: Configuration of the bucket's data retention policy for how long objects in the bucket should be retained.
-    type: |-
-      object({
-          is_locked        = bool
-          retention_period = number
-        })
-    required: false
-  - name: storage_class
-    description: The Storage Class of the new bucket.
-    type: string
-    required: false
-  - name: versioning
-    description: While set to true, versioning is fully enabled for this bucket.
-    type: bool
-    default: true
-    required: false
-  - name: website
-    description: 'Map of website values. Supported attributes: main_page_suffix, not_found_page'
-    type: map(any)
-    default: {}
-    required: false
-  - name: autoclass
-    description: While set to true, autoclass is enabled for this bucket.
-    type: bool
-    default: false
-    required: false
-  outputs:
-  - name: bucket
-    description: The created storage bucket
-  - name: name
-    description: Bucket name.
-  - name: url
-    description: Bucket URL.
-  roles:
-  - level: Project
+              # Object with keys:
+              # - age - (Optional) Minimum age of an object in days to satisfy this condition.
+              # - created_before - (Optional) Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.
+              # - with_state - (Optional) Match to live and/or archived objects. Supported values include: "LIVE", "ARCHIVED", "ANY".
+              # - matches_storage_class - (Optional) Storage Class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.
+              # - matches_prefix - (Optional) One or more matching name prefixes to satisfy this condition.
+              # - matches_suffix - (Optional) One or more matching name suffixes to satisfy this condition
+              # - num_newer_versions - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
+              condition = any
+            }))
+        defaultValue: []
+      - name: location
+        description: The location of the bucket.
+        varType: string
+        required: true
+      - name: log_bucket
+        description: The bucket that will receive log objects.
+        varType: string
+      - name: log_object_prefix
+        description: The object prefix for log objects. If it's not provided, by default GCS sets this to this bucket's name
+        varType: string
+      - name: name
+        description: The name of the bucket.
+        varType: string
+        required: true
+      - name: project_id
+        description: The ID of the project to create the bucket in.
+        varType: string
+        required: true
+      - name: public_access_prevention
+        description: Prevents public access to a bucket. Acceptable values are inherited or enforced. If inherited, the bucket uses public access prevention, only if the bucket is subject to the public access prevention organization policy constraint.
+        varType: string
+        defaultValue: inherited
+      - name: retention_policy
+        description: Configuration of the bucket's data retention policy for how long objects in the bucket should be retained.
+        varType: |-
+          object({
+              is_locked        = bool
+              retention_period = number
+            })
+      - name: soft_delete_policy
+        description: Soft delete policies to apply. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#nested_soft_delete_policy
+        varType: |-
+          object({
+              retention_duration_seconds = optional(number)
+            })
+        defaultValue: {}
+      - name: storage_class
+        description: The Storage Class of the new bucket.
+        varType: string
+      - name: versioning
+        description: While set to true, versioning is fully enabled for this bucket.
+        varType: bool
+        defaultValue: true
+      - name: website
+        description: "Map of website values. Supported attributes: main_page_suffix, not_found_page"
+        varType: map(any)
+        defaultValue: {}
+    outputs:
+      - name: bucket
+        description: The created storage bucket
+      - name: name
+        description: Bucket name.
+      - name: url
+        description: Bucket URL.
+  requirements:
     roles:
-    - roles/storage.admin
-    - roles/iam.serviceAccountUser
-  services:
-  - iam.googleapis.com
-  - storage-api.googleapis.com
-  - cloudresourcemanager.googleapis.com
-  - compute.googleapis.com
-  - serviceusage.googleapis.com
+      - level: Project
+        roles:
+          - roles/cloudkms.admin
+          - roles/iam.serviceAccountUser
+          - roles/storage.admin
+    services:
+      - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - compute.googleapis.com
+      - iam.googleapis.com
+      - serviceusage.googleapis.com
+      - storage-api.googleapis.com


### PR DESCRIPTION
This PR makes below changes,

1. Regenerate the metadata in current format. The current metadata is old and not in the current format.
2. Add new connection metadata for incoming connection from cloud-run module