### PR TITLE
fix(TPG>=6)!: remove deprecated no_age

### DIFF
--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -23,7 +23,7 @@ resource "google_storage_bucket" "bucket" {
   labels                      = var.labels
   force_destroy               = var.force_destroy
   public_access_prevention    = var.public_access_prevention
-
+ 
   versioning {
     enabled = var.versioning
   }
@@ -81,7 +81,6 @@ resource "google_storage_bucket" "bucket" {
       }
       condition {
         age                        = lookup(lifecycle_rule.value.condition, "age", null)
-        no_age                     = lookup(lifecycle_rule.value.condition, "no_age", null)
         created_before             = lookup(lifecycle_rule.value.condition, "created_before", null)
         with_state                 = lookup(lifecycle_rule.value.condition, "with_state", contains(keys(lifecycle_rule.value.condition), "is_live") ? (lifecycle_rule.value.condition["is_live"] ? "LIVE" : null) : null)
         matches_storage_class      = contains(keys(lifecycle_rule.value.condition), "matches_storage_class") ? split(",", lifecycle_rule.value.condition["matches_storage_class"]) : null

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -23,7 +23,7 @@ resource "google_storage_bucket" "bucket" {
   labels                      = var.labels
   force_destroy               = var.force_destroy
   public_access_prevention    = var.public_access_prevention
- 
+
   versioning {
     enabled = var.versioning
   }

--- a/modules/simple_bucket/versions.tf
+++ b/modules/simple_bucket/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.22, < 7"
+      version = ">= 6, < 7"
     }
   }
 


### PR DESCRIPTION
`no_age` is no longer needed or supported with TPGv6