### PR TITLE
fix: Fix apphub uri and id representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Functional examples are included in the
 
 | Name | Description |
 |------|-------------|
-| apphub\_service\_uri | Service URI in CAIS style to be used by Apphub. |
+| apphub\_service\_uri | URI in CAIS style to be used by Apphub. |
 | bucket | Bucket resource (for single use). |
 | buckets | Bucket resources as list. |
 | buckets\_map | Bucket resources by name. |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -240,7 +240,7 @@ spec:
         defaultValue: {}
     outputs:
       - name: apphub_service_uri
-        description: Service URI in CAIS style to be used by Apphub.
+        description: URI in CAIS style to be used by Apphub.
         type:
           - tuple
           - - - object

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -242,13 +242,10 @@ spec:
       - name: apphub_service_uri
         description: Service URI in CAIS style to be used by Apphub.
         type:
-          - object
-          - service_id:
-              - tuple
-              - - string
-            service_uri:
-              - tuple
-              - - string
+          - tuple
+          - - - object
+              - service_id: string
+                service_uri: string
       - name: bucket
         description: Bucket resource (for single use).
         type:

--- a/modules/simple_bucket/README.md
+++ b/modules/simple_bucket/README.md
@@ -64,6 +64,7 @@ Functional examples are included in the
 
 | Name | Description |
 |------|-------------|
+| apphub\_service\_uri | Service URI in CAIS style to be used by Apphub. |
 | bucket | The created storage bucket |
 | internal\_kms\_configuration | The intenal KMS Resource. |
 | name | Bucket name. |

--- a/modules/simple_bucket/README.md
+++ b/modules/simple_bucket/README.md
@@ -64,7 +64,7 @@ Functional examples are included in the
 
 | Name | Description |
 |------|-------------|
-| apphub\_service\_uri | Service URI in CAIS style to be used by Apphub. |
+| apphub\_service\_uri | URI in CAIS style to be used by Apphub. |
 | bucket | The created storage bucket |
 | internal\_kms\_configuration | The intenal KMS Resource. |
 | name | Bucket name. |

--- a/modules/simple_bucket/metadata.yaml
+++ b/modules/simple_bucket/metadata.yaml
@@ -85,12 +85,12 @@ spec:
               source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
               version: ~> 0.13
             spec:
-              outputExpr: '{"member": service_account_id.member, "role": "roles/storage.objectAdmin"}'
+              outputExpr: "{\"member\": service_account_id.member, \"role\": \"roles/storage.objectAdmin\"}"
           - source:
               source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
               version: ~> 4.4
             spec:
-              outputExpr: '{"member": iam_email, "role": "roles/storage.objectAdmin"}'
+              outputExpr: "{\"member\": iam_email, \"role\": \"roles/storage.objectAdmin\"}"
       - name: retention_policy
         description: Configuration of the bucket's data retention policy for how long objects in the bucket should be retained.
         varType: |-
@@ -167,7 +167,7 @@ spec:
         defaultValue: {}
     outputs:
       - name: apphub_service_uri
-        description: Service URI in CAIS style to be used by Apphub.
+        description: URI in CAIS style to be used by Apphub.
         type:
           - object
           - service_id: string

--- a/modules/simple_bucket/metadata.yaml
+++ b/modules/simple_bucket/metadata.yaml
@@ -47,7 +47,7 @@ spec:
         varType: string
         required: true
       - name: location
-        description: The location of the bucket.
+        description: The location of the bucket. See https://cloud.google.com/storage/docs/locations.
         varType: string
         required: true
       - name: storage_class
@@ -83,7 +83,7 @@ spec:
         connections:
           - source:
               source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
-              version: "~> 0.12.0"
+              version: ~> 0.12.0
             spec:
               outputExpr: service_account_id.member
               inputPath: member
@@ -105,7 +105,7 @@ spec:
         varType: any
         defaultValue: []
       - name: encryption
-        description: A Cloud KMS key that will be used to encrypt objects inserted into this bucket. If default_kms_key_name is set to 'null' a new keyring and key pair will be created and used to encrypt bucket using CMEK.
+        description: A Cloud KMS key that will be used to encrypt objects inserted into this bucket. To use a Cloud KMS key automatically created by the module use `internal_encryption_config`.
         varType: |-
           object({
               default_kms_key_name = string
@@ -151,7 +151,23 @@ spec:
               retention_duration_seconds = optional(number)
             })
         defaultValue: {}
+      - name: internal_encryption_config
+        description: "  Configuration for the creation of an internal Google Cloud Key Management Service (KMS) Key for use as Customer-managed encryption key (CMEK) for the GCS Bucket\n  instead of creating one in advance and providing the key in the variable `encryption.default_kms_key_name`.\n  create_encryption_key: If `true` a Google Cloud Key Management Service (KMS) KeyRing and a Key will be created\n  prevent_destroy: Set the prevent_destroy lifecycle attribute on keys.\n  key_destroy_scheduled_duration: Set the period of time that versions of keys spend in the `DESTROY_SCHEDULED` state before transitioning to `DESTROYED`.\n  key_rotation_period: Generate a new key every time this period passes.\n"
+        varType: |-
+          object({
+              create_encryption_key          = optional(bool, false)
+              prevent_destroy                = optional(bool, false)
+              key_destroy_scheduled_duration = optional(string, null)
+              key_rotation_period            = optional(string, "7776000s")
+            })
+        defaultValue: {}
     outputs:
+      - name: apphub_service_uri
+        description: Service URI in CAIS style to be used by Apphub.
+        type:
+          - object
+          - service_id: string
+            service_uri: string
       - name: bucket
         description: The created storage bucket
         type:
@@ -219,6 +235,7 @@ spec:
                         matches_suffix:
                           - list
                           - string
+                        no_age: bool
                         noncurrent_time_before: string
                         num_newer_versions: number
                         send_age_if_zero: bool
@@ -269,6 +286,8 @@ spec:
               - - object
                 - main_page_suffix: string
                   not_found_page: string
+      - name: internal_kms_configuration
+        description: The intenal KMS Resource.
       - name: name
         description: Bucket name.
         type: string
@@ -292,5 +311,3 @@ spec:
     providerVersions:
       - source: hashicorp/google
         version: ">= 5.43.0, < 7"
-      - source: hashicorp/random
-        version: ">= 2.1"

--- a/modules/simple_bucket/metadata.yaml
+++ b/modules/simple_bucket/metadata.yaml
@@ -85,12 +85,12 @@ spec:
               source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
               version: ~> 0.13
             spec:
-              outputExpr: "{\"member\": service_account_id.member, \"role\": \"roles/storage.objectAdmin\"}"
+              outputExpr: '{"member": service_account_id.member, "role": "roles/storage.objectAdmin"}'
           - source:
               source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
               version: ~> 4.4
             spec:
-              outputExpr: "{\"member\": iam_email, \"role\": \"roles/storage.objectAdmin\"}"
+              outputExpr: '{"member": iam_email, "role": "roles/storage.objectAdmin"}'
       - name: retention_policy
         description: Configuration of the bucket's data retention policy for how long objects in the bucket should be retained.
         varType: |-

--- a/modules/simple_bucket/outputs.tf
+++ b/modules/simple_bucket/outputs.tf
@@ -36,8 +36,8 @@ output "internal_kms_configuration" {
 
 output "apphub_service_uri" {
   value = {
-    service_uri = "//storage.googleapis.com/${element(split("/b/", google_storage_bucket.bucket.self_link), 1)}"
-    service_id  = substr(format("%s-%s", google_storage_bucket.bucket.name, md5(var.project_id)), 0, 63)
+    service_uri = "//storage.googleapis.com/${google_storage_bucket.bucket.name}"
+    service_id  = substr(google_storage_bucket.bucket.name, 0, 63)
   }
   description = "URI in CAIS style to be used by Apphub."
 }

--- a/modules/simple_bucket/outputs.tf
+++ b/modules/simple_bucket/outputs.tf
@@ -33,3 +33,11 @@ output "internal_kms_configuration" {
   description = "The intenal KMS Resource."
   value       = var.internal_encryption_config.create_encryption_key ? module.encryption_key[0] : null
 }
+
+output "apphub_service_uri" {
+  value = {
+    service_uri = "//storage.googleapis.com/Bucket/${element(split("/b/", google_storage_bucket.bucket.self_link), 1)}"
+    service_id  = substr(format("%s-%s", google_storage_bucket.bucket.name, md5(var.project_id)), 0, 63)
+  }
+  description = "Service URI in CAIS style to be used by Apphub."
+}

--- a/modules/simple_bucket/outputs.tf
+++ b/modules/simple_bucket/outputs.tf
@@ -36,8 +36,8 @@ output "internal_kms_configuration" {
 
 output "apphub_service_uri" {
   value = {
-    service_uri = "//storage.googleapis.com/Bucket/${element(split("/b/", google_storage_bucket.bucket.self_link), 1)}"
+    service_uri = "//storage.googleapis.com/${element(split("/b/", google_storage_bucket.bucket.self_link), 1)}"
     service_id  = substr(format("%s-%s", google_storage_bucket.bucket.name, md5(var.project_id)), 0, 63)
   }
-  description = "Service URI in CAIS style to be used by Apphub."
+  description = "URI in CAIS style to be used by Apphub."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -71,8 +71,8 @@ output "hmac_keys" {
 
 output "apphub_service_uri" {
   value = [for bucket in local.buckets_list : {
-    service_uri = "//storage.googleapis.com/Bucket/${element(split("/b/", bucket.self_link), 1)}"
+    service_uri = "//storage.googleapis.com/${element(split("/b/", bucket.self_link), 1)}"
     service_id  = substr(format("%s-%s", bucket.name, md5(var.project_id)), 0, 63)
   }]
-  description = "Service URI in CAIS style to be used by Apphub."
+  description = "URI in CAIS style to be used by Apphub."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -71,8 +71,8 @@ output "hmac_keys" {
 
 output "apphub_service_uri" {
   value = [for bucket in local.buckets_list : {
-    service_uri = "//storage.googleapis.com/${element(split("/b/", bucket.self_link), 1)}"
-    service_id  = substr(format("%s-%s", bucket.name, md5(var.project_id)), 0, 63)
+    service_uri = "//storage.googleapis.com/${bucket.name}"
+    service_id  = substr(bucket.name, 0, 63)
   }]
   description = "URI in CAIS style to be used by Apphub."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,9 +70,9 @@ output "hmac_keys" {
 }
 
 output "apphub_service_uri" {
-  value = {
-    service_uri = local.buckets_list[*].self_link
-    service_id  = local.buckets_list[*].name
-  }
+  value = [for bucket in local.buckets_list : {
+    service_uri = "//storage.googleapis.com/Bucket/${element(split("/b/", bucket.self_link), 1)}"
+    service_id  = substr(format("%s-%s", bucket.name, md5(var.project_id)), 0, 63)
+  }]
   description = "Service URI in CAIS style to be used by Apphub."
 }


### PR DESCRIPTION
Resource representation for GCS buckets should be `//storage.googleapis.com/<bucket-name>`. 

Also improved the logic of id generation.