### PR TITLE
fix!: remove apphub_service_uri from output of simple_bucket

### DIFF
--- a/docs/upgrading_to_v9.0.md
+++ b/docs/upgrading_to_v9.0.md
@@ -1,0 +1,14 @@
+# Upgrading to v9.0
+
+The v9.0 release contains backwards-incompatible changes.
+
+## Replace uses of apphub_service_uri
+
+This release removes apphub_service_uri output. You can replace use of `apphub_service_uri` by forming the desired output as below,
+
+```
+{
+    service_uri = "//storage.googleapis.com/${module.simple_bucket.name}"
+    service_id  = substr(module.simple_bucket.name, 0, 63)
+  }
+```

--- a/modules/simple_bucket/README.md
+++ b/modules/simple_bucket/README.md
@@ -64,7 +64,6 @@ Functional examples are included in the
 
 | Name | Description |
 |------|-------------|
-| apphub\_service\_uri | URI in CAIS style to be used by Apphub. |
 | bucket | The created storage bucket |
 | internal\_kms\_configuration | The intenal KMS Resource. |
 | name | Bucket name. |

--- a/modules/simple_bucket/metadata.yaml
+++ b/modules/simple_bucket/metadata.yaml
@@ -166,12 +166,6 @@ spec:
             })
         defaultValue: {}
     outputs:
-      - name: apphub_service_uri
-        description: URI in CAIS style to be used by Apphub.
-        type:
-          - object
-          - service_id: string
-            service_uri: string
       - name: bucket
         description: The created storage bucket
         type:

--- a/modules/simple_bucket/outputs.tf
+++ b/modules/simple_bucket/outputs.tf
@@ -33,11 +33,3 @@ output "internal_kms_configuration" {
   description = "The intenal KMS Resource."
   value       = var.internal_encryption_config.create_encryption_key ? module.encryption_key[0] : null
 }
-
-output "apphub_service_uri" {
-  value = {
-    service_uri = "//storage.googleapis.com/${google_storage_bucket.bucket.name}"
-    service_id  = substr(google_storage_bucket.bucket.name, 0, 63)
-  }
-  description = "URI in CAIS style to be used by Apphub."
-}


### PR DESCRIPTION
GCS buckets are not supported in AppHub yet!