### PR TITLE
fix: Tighten up per_module_roles

### DIFF
--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,25 +17,17 @@
 locals {
   per_module_roles = {
     simple_bucket = [
-      "roles/storage.admin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
       "roles/iam.serviceAccountUser",
-      "roles/cloudkms.admin",
-      "roles/logging.logWriter",
+      "roles/storage.admin",
     ]
     root = [
-      "roles/resourcemanager.projectIamAdmin",
-      "roles/serviceusage.serviceUsageAdmin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
       "roles/storage.admin",
-      "roles/iam.serviceAccountAdmin",
-      "roles/iam.serviceAccountUser",
     ]
   }
 
-  int_required_roles = concat([
-    "roles/cloudkms.cryptoKeyEncrypterDecrypter",
-    "roles/iam.serviceAccountUser",
-    "roles/storage.admin",
-  ], flatten(values(local.per_module_roles)))
+  int_required_roles = tolist(toset(flatten(values(local.per_module_roles))))
 }
 
 resource "google_service_account" "int_test" {


### PR DESCRIPTION
An attempt to understand and/or improve on the contents I'm seeing in per_module_roles. I don't understand why stuff like projectIamAdmin is in there, and IMO it really shouldn't be. Unless I'm missing something.