### PR TITLE
fix: IAM bindings lost when bucket is replaced

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,10 @@ resource "google_storage_bucket_iam_binding" "admins" {
       ),
     ),
   )
+
+  lifecycle {
+    replace_triggered_by = [google_storage_bucket.buckets[each.value]]
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "creators" {
@@ -227,6 +231,10 @@ resource "google_storage_bucket_iam_binding" "creators" {
       ),
     ),
   )
+
+  lifecycle {
+    replace_triggered_by = [google_storage_bucket.buckets[each.value]]
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "viewers" {
@@ -242,6 +250,10 @@ resource "google_storage_bucket_iam_binding" "viewers" {
       ),
     ),
   )
+
+  lifecycle {
+    replace_triggered_by = [google_storage_bucket.buckets[each.value]]
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "hmac_key_admins" {
@@ -257,6 +269,10 @@ resource "google_storage_bucket_iam_binding" "hmac_key_admins" {
       ),
     ),
   )
+
+  lifecycle {
+    replace_triggered_by = [google_storage_bucket.buckets[each.key]]
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "storage_admins" {
@@ -272,6 +288,10 @@ resource "google_storage_bucket_iam_binding" "storage_admins" {
       ),
     ),
   )
+
+  lifecycle {
+    replace_triggered_by = [google_storage_bucket.buckets[each.value]]
+  }
 }
 
 resource "google_storage_bucket_object" "folders" {


### PR DESCRIPTION
Adds `replace_triggered_by` lifecycle meta-argument to all IAM binding resources to ensure they are replaced whenever the bucket is replaced:

```hcl
resource "google_storage_bucket_iam_binding" "admins" {
  for_each = var.set_admin_roles ? local.names_set : []
  bucket   = google_storage_bucket.buckets[each.value].name
  role     = "roles/storage.objectAdmin"
  members  = ...

  lifecycle {
    replace_triggered_by = [google_storage_bucket.buckets[each.value]]
  }
}
```

## Root Cause

The IAM binding resources reference the bucket by name:

```hcl
resource "google_storage_bucket_iam_binding" "admins" {
  for_each = var.set_admin_roles ? local.names_set : []
  bucket   = google_storage_bucket.buckets[each.value].name  # References bucket name
  role     = "roles/storage.objectAdmin"
  members  = ...
}
```

When the bucket is replaced:
- The bucket **name** stays the same (only location changes)
- The `for_each` key doesn't change
- The `members` don't change
- Terraform sees no changes to the IAM binding resource configuration
- **But** the underlying GCP bucket was destroyed and recreated, losing all IAM bindings
