### PR TITLE
Added support for configuring terminal_storage_class in Autoclass

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,11 @@ resource "google_storage_bucket" "buckets" {
       lower(each.value),
       false,
     )
+    terminal_storage_class = lookup(
+      var.autoclass,
+      lower(each.value),
+      false
+    ) ? lookup(var.terminal_storage_class, lower(each.value), "NEARLINE") : null
   }
   hierarchical_namespace {
     enabled = lookup(

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "google_storage_bucket" "buckets" {
     terminal_storage_class = lookup(
       var.autoclass,
       lower(each.value),
-      false
+      false,
     ) ? lookup(var.terminal_storage_class, lower(each.value), "NEARLINE") : null
   }
   hierarchical_namespace {

--- a/modules/simple_bucket/main.tf
+++ b/modules/simple_bucket/main.tf
@@ -34,7 +34,8 @@ resource "google_storage_bucket" "bucket" {
   }
 
   autoclass {
-    enabled = var.autoclass
+    enabled                = var.autoclass
+    terminal_storage_class = var.autoclass ? var.terminal_storage_class : null
   }
 
   hierarchical_namespace {

--- a/modules/simple_bucket/variables.tf
+++ b/modules/simple_bucket/variables.tf
@@ -75,6 +75,12 @@ variable "autoclass" {
   default     = false
 }
 
+variable "terminal_storage_class" {
+  description = "Optional final storage class for objects when autoclass is enabled. Defaults to NEARLINE."
+  type        = string
+  default     = "NEARLINE"
+}
+
 variable "hierarchical_namespace" {
   description = "When set to true, hierarchical namespace is enable for this bucket."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "autoclass" {
   default     = {}
 }
 
+variable "terminal_storage_class" {
+  description = "Optional map of lowercase unprefixed bucket name => terminal storage class, defaults to NEARLINE."
+  type        = map(string)
+  default     = {}
+}
+
 variable "hierarchical_namespace" {
   description = "Optional map of lowercase unprefixed bucket name => boolean, defaults to false."
   type        = map(bool)


### PR DESCRIPTION
I have implemented the enhancement requested in [Issue #395](https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/395) by exposing the ability to configure the `terminal_storage_class` when Google Cloud Storage **Autoclass is enabled**


Previously, the module only exposed the `enabled` flag for `Autoclass`, defaulting the terminal storage class to NEARLINE with no option to override it. This update introduces a new variable, `terminal_storage_class`, allowing users to specify a custom value (example: ARCHIVE) per bucket. defaults to `NEARLINE`

```diff
autoclass {
  enabled = lookup(
    var.autoclass,
    lower(each.value),
    false,
  )
+  terminal_storage_class = lookup(
+    var.autoclass,
+    lower(each.value),
+    false,
+  ) ? lookup(var.terminal_storage_class, lower(each.value), "NEARLINE") : null
}
```
#### Add new variable 
```diff
 variable "terminal_storage_class" {
   description = "Optional map of lowercase unprefixed bucket name => terminal storage class, defaults to NEARLINE."
   type        = map(string)
   default     = {}
 }
```